### PR TITLE
chore(ci): set up GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Lint
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Build release
+        run: cargo build --release

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub struct Config {
     pub check: CheckConfig,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct CheckConfig {
     pub max: Option<usize>,
@@ -33,16 +33,6 @@ impl Default for Config {
             exclude_dirs: vec![],
             exclude_patterns: vec![],
             check: CheckConfig::default(),
-        }
-    }
-}
-
-impl Default for CheckConfig {
-    fn default() -> Self {
-        Self {
-            max: None,
-            max_new: None,
-            block_tags: vec![],
         }
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -16,7 +16,7 @@ static ISSUE_REF_RE: LazyLock<Regex> =
 fn extract_issue_ref(message: &str) -> Option<String> {
     ISSUE_REF_RE.captures(message).map(|caps| {
         caps.get(1)
-            .or_else(|| caps.get(2).map(|m| m))
+            .or_else(|| caps.get(2))
             .map(|m| {
                 if caps.get(1).is_some() {
                     m.as_str().to_string()


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` with Linux-only CI on `ubuntu-latest`
- Trigger on push to `main` and PRs targeting `main`
- Steps: checkout, Rust stable toolchain, cargo cache, `fmt --check`, `clippy -- -D warnings`, `test`, `build --release`
- Fix two clippy warnings to pass CI lint gate

Closes #18

## Test Plan

- [x] `cargo fmt --check` passes locally
- [x] `cargo clippy -- -D warnings` passes locally
- [x] `cargo test` — all 76 tests pass
- [x] CI workflow runs successfully on this PR