### PR TITLE
chore(workflow): add Claude Code commands and enforce /tdd-workflow

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,144 @@
+# Implement Issue
+
+Implement GitHub issue #$ARGUMENTS following the development workflow defined in `docs/DEVELOPMENT_WORKFLOW.md`. Execute each step in order — do not skip steps.
+
+## Prerequisites
+
+Before starting, read these files:
+- `docs/DEVELOPMENT_WORKFLOW.md` — the authoritative workflow definition
+- `CLAUDE.md` — project conventions and build commands
+
+## Step 1: Pick the Issue
+
+```bash
+gh issue view $ARGUMENTS
+```
+
+- Read the issue description, acceptance criteria, and any linked discussions
+- Identify dependencies on other issues — if a dependency is still open, stop and inform the user
+- Assign yourself to the issue:
+
+```bash
+gh issue edit $ARGUMENTS --add-assignee @me
+```
+
+## Step 2: Create a Branch
+
+```bash
+git switch main
+git pull --rebase
+```
+
+Determine the branch type from the issue title/labels:
+- `feature/` for new functionality (label: `enhancement`)
+- `fix/` for bug fixes (label: `bug`)
+- `refactor/` for restructuring
+- `docs/` for documentation
+- `chore/` for maintenance
+- `perf/` for performance
+
+Create the branch:
+
+```bash
+git switch -c <type>/<short-description>
+```
+
+## Step 3: Post Implementation Plan
+
+Enter Plan mode to design the implementation approach. After the plan is approved:
+
+- Post the plan as a comment on the issue:
+
+```bash
+gh issue comment $ARGUMENTS --body "$(cat <<'EOF'
+## Implementation Plan
+
+### Overview
+<brief description>
+
+### Changes
+- **module** — what and why
+
+### Testing Strategy
+- What tests will be added
+EOF
+)"
+```
+
+## Step 4: Implement with TDD
+
+Use the `/tdd-workflow` skill to drive the implementation:
+
+```
+/tdd-workflow
+```
+
+This skill enforces Kent Beck's 5-step cycle: Test List → Write Test → Make Pass → Refactor → Repeat.
+
+Run tests with:
+
+```bash
+cargo test
+cargo fmt --check
+cargo check
+```
+
+## Step 5: Update README (if features changed)
+
+If the change adds or modifies user-facing features (new commands, new flags, changed behavior):
+
+- Use the `/feature-writing` skill to draft the README update
+- Skip this step for internal optimizations, refactoring, test-only changes, or docs-only changes
+
+## Step 6: Commit
+
+Use the `/commit` skill:
+
+```
+/commit
+```
+
+The commit message must:
+- Follow conventional commit format: `type(scope): description (#$ARGUMENTS)`
+- Reference the issue number
+
+## Step 7: Create a Pull Request
+
+```bash
+git push -u origin HEAD
+```
+
+Create the PR linking to the issue:
+
+```bash
+gh pr create \
+  --title "type(scope): description" \
+  --body "$(cat <<'EOF'
+## Summary
+
+<brief description of changes>
+
+Closes #$ARGUMENTS
+
+## Test Plan
+
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Manual testing completed
+EOF
+)"
+```
+
+## Step 8: Merge
+
+After CI passes:
+
+```bash
+gh pr merge --rebase --delete-branch
+```
+
+Verify the issue was auto-closed:
+
+```bash
+gh issue view $ARGUMENTS
+```

--- a/.claude/commands/pick-issue.md
+++ b/.claude/commands/pick-issue.md
@@ -1,0 +1,40 @@
+# Pick Next Issue
+
+Analyze open GitHub issues and recommend the best issue to work on next.
+
+## Steps
+
+1. **Fetch open issues with full details:**
+
+```bash
+gh issue list --state open --json number,title,labels,body --limit 50
+```
+
+2. **Check current branch and working tree state:**
+
+```bash
+git status
+git branch --show-current
+```
+
+3. **Analyze each issue for:**
+   - **Dependencies**: Read issue body for references to other issues (`#N`, `depends on`, `requires`, `after`). An issue is blocked if its dependency is still open.
+   - **Complexity**: Estimate from issue body (new subcommand = high, flag addition = medium, docs/chore = low)
+   - **Priority signals**: Labels, whether other issues depend on it (blocker for others = higher priority), standalone vs dependency chain
+   - **Current state**: Whether a branch already exists for it (`git branch --list '*issue-keyword*'`)
+
+4. **Categorize issues into tiers:**
+   - **Tier 1 — Ready now**: No open dependencies, standalone, low-to-medium complexity
+   - **Tier 2 — Ready but complex**: No open dependencies, high complexity
+   - **Tier 3 — Blocked**: Has open dependencies that must be completed first
+
+5. **Present a recommendation table** sorted by tier, then by priority:
+
+```
+| Tier | Issue | Title | Complexity | Blocked By |
+|------|-------|-------|------------|------------|
+```
+
+6. **Recommend the top 3 issues** with a brief rationale for each, explaining why it should be picked next.
+
+7. **Ask the user** which issue they want to work on. Once they choose, tell them to run `/implement <issue-number>` to start.

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -26,7 +26,8 @@ sequenceDiagram
     Dev->>GH: gh issue comment <number> --body "plan"
     GH-->>Dev: Plan posted to issue
 
-    Note over Dev,CI: 4. Implement with TDD
+    Note over Dev,CI: 4. Implement with TDD (/tdd-workflow)
+    Dev->>Dev: /tdd-workflow
     loop Red-Green-Refactor
         Dev->>Repo: Write failing test
         Dev->>CI: cargo test (Red)
@@ -64,7 +65,7 @@ sequenceDiagram
 
 - **No work without an issue** — every change must be linked to a GitHub issue
 - **Use `gh` CLI** for all GitHub operations (issues, PRs, project board)
-- **Follow TDD** — write failing tests first, then implement, then refactor
+- **Follow TDD with `/tdd-workflow`** — always use the `tdd-workflow` skill for all implementation work; it enforces the Red-Green-Refactor cycle
 - **Post the plan to the issue** — share the implementation plan as a comment before coding
 - **Link PRs to issues** with `Closes #<number>` for auto-closing
 - **Update README** when adding or changing user-facing features — use the `feature-writing` skill for the Features section
@@ -140,11 +141,19 @@ EOF
 
 ### 4. Implement with TDD
 
-Follow the Red-Green-Refactor cycle:
+**Always use the `/tdd-workflow` skill to drive implementation.** This skill enforces Kent Beck's canonical 5-step TDD workflow (Test List, Write Test, Make Pass, Refactor, Repeat) and ensures strict vertical-slice cycles.
 
-1. **Red** — Write a failing test that defines the expected behavior
-2. **Green** — Write the minimum code to make the test pass
-3. **Refactor** — Clean up the code while keeping tests green
+```
+/tdd-workflow
+```
+
+The skill manages the Red-Green-Refactor cycle automatically:
+
+1. **Test List** — Enumerate the test cases needed for the feature
+2. **Red** — Write a failing test that defines the expected behavior
+3. **Green** — Write the minimum code to make the test pass
+4. **Refactor** — Clean up the code while keeping tests green
+5. **Repeat** — Move to the next test from the list
 
 ```bash
 # Run tests continuously during development


### PR DESCRIPTION
## Summary

- Add `/pick-issue` command that analyzes open issues by dependencies, complexity, and priority to recommend the next issue to work on
- Add `/implement <number>` command that walks through the full DEVELOPMENT_WORKFLOW.md 8-step cycle (issue → branch → plan → TDD → README → commit → PR → merge), orchestrating existing skills (`/tdd-workflow`, `/commit`, `/feature-writing`)
- Update `docs/DEVELOPMENT_WORKFLOW.md` to mandate `/tdd-workflow` skill usage for all TDD implementation work

#17

## Test plan

- [x] Run `/pick-issue` and verify it fetches issues and produces a tiered recommendation
- [x] Run `/implement <number>` on a test issue and verify it follows each workflow step in order
- [x] Verify `/tdd-workflow` is referenced in both the Rules section and Step 4 of the workflow doc