### PR TITLE
docs(readme): add fetch-depth note for CI diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,15 @@ cp -r .claude/skills/todox ~/.claude/skills/
 
 ### PR review with diff
 
+> **Note:** `todox diff` and `todox check --since` need access to the base ref's git history.
+> `actions/checkout@v4` uses `fetch-depth: 1` (shallow clone) by default, which means the base
+> SHA is not available. Set `fetch-depth: 0` to fetch the full history.
+
 ```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0  # Required for todox to access the base ref
+
 - name: Check new TODOs
   run: |
     todox check --max-new 0 --since origin/main


### PR DESCRIPTION
## Summary

Add a note to the README's "PR review with diff" CI Integration section explaining that `actions/checkout@v4` uses shallow clone (`fetch-depth: 1`) by default, which causes `todox diff` and `todox check --since` to fail. Includes an updated YAML example with `fetch-depth: 0`.

Closes #42

## Test Plan

- [ ] Manual review of README formatting and accuracy