### PR TITLE
feat(list): add group-by and filter flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
+ "globset",
  "ignore",
  "predicates",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Track TODO/FIXME/HACK comments with git-aware diff and CI gate"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+globset = "0.4"
 ignore = "0.4"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Track TODO/FIXME/HACK comments in your codebase with git-aware diff and CI gate.
 
 **`todox list`**
 
-TODO comments scatter across hundreds of files, making it hard to know what's outstanding. `todox list` scans your entire codebase and displays every TODO, FIXME, HACK, XXX, BUG, and NOTE comment, grouped by file with color-coded tags. Run `todox list` or use the short alias `todox ls`.
+TODO comments scatter across hundreds of files, making it hard to know what's outstanding. `todox list` scans your entire codebase and displays every TODO, FIXME, HACK, XXX, BUG, and NOTE comment with color-coded tags, and supports flexible grouping (`--group-by file|tag|priority|author|dir`) and filtering by priority, author, path glob, and result limit. Run `todox list` or use the short alias `todox ls`.
 
 **`todox diff <ref>`**
 
@@ -68,6 +68,23 @@ todox ls
 # Filter by tag
 todox list --tag FIXME
 todox list --tag TODO --tag BUG
+
+# Filter by priority, author, or path
+todox list --priority urgent
+todox list --author alice
+todox list --path "src/**"
+
+# Combine filters
+todox list --priority urgent --author alice --path "src/**"
+
+# Limit results
+todox list --limit 10
+
+# Group by tag, priority, author, or directory (default: file)
+todox list --group-by tag
+todox list --group-by priority
+todox list --group-by author
+todox list --group-by dir
 
 # Sort by priority or tag severity
 todox list --sort priority

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
+use crate::model;
+
 #[derive(Parser)]
 #[command(
     name = "todox",
@@ -39,6 +41,21 @@ pub enum Command {
 
         #[arg(long, value_enum, default_value = "file")]
         sort: SortBy,
+
+        #[arg(long, value_enum, default_value = "file")]
+        group_by: GroupBy,
+
+        #[arg(long, value_enum)]
+        priority: Vec<PriorityFilter>,
+
+        #[arg(long)]
+        author: Option<String>,
+
+        #[arg(long)]
+        path: Option<String>,
+
+        #[arg(long)]
+        limit: Option<usize>,
     },
 
     Diff {
@@ -71,4 +88,30 @@ pub enum SortBy {
     File,
     Tag,
     Priority,
+}
+
+#[derive(Clone, ValueEnum)]
+pub enum GroupBy {
+    File,
+    Tag,
+    Priority,
+    Author,
+    Dir,
+}
+
+#[derive(Clone, ValueEnum)]
+pub enum PriorityFilter {
+    Normal,
+    High,
+    Urgent,
+}
+
+impl PriorityFilter {
+    pub fn to_priority(&self) -> model::Priority {
+        match self {
+            PriorityFilter::Normal => model::Priority::Normal,
+            PriorityFilter::High => model::Priority::High,
+            PriorityFilter::Urgent => model::Priority::Urgent,
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add `--group-by` flag (file/tag/priority/author/dir) for flexible output grouping
- Add `--priority`, `--author`, `--path` filters for slicing TODO results
- Add `--limit` flag to cap output size
- Update README with new flag documentation

Closes #21

## Test Plan

- [x] Unit tests pass (`cargo test` — 156 tests)
- [x] 10 new integration tests added covering:
  - `--priority urgent` filter
  - `--author alice` filter
  - `--path "src/**"` glob filter
  - `--limit 2` truncation
  - `--group-by tag/priority/author/dir` grouping
  - `--group-by priority --format json` (flat JSON output)
  - Combined filter composition
- [x] `cargo fmt --check` clean
- [x] `cargo check` no warnings