### PR TITLE
feat(stats): add stats subcommand with dashboard summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ TODO comments scatter across hundreds of files, making it hard to know what's ou
 
 New TODOs slip into pull requests unnoticed while resolved ones go unrecognized. `todox diff` compares the current working tree against any git ref and shows exactly which TODOs were added or removed. Run `todox diff main` to compare against your main branch.
 
+**`todox stats`**
+
+A flat list of TODOs makes it hard to see the big picture — whether tech debt is growing, who owns the most items, and which files are hotspots. `todox stats` provides a dashboard summary with tag and author breakdowns, priority distribution, and top files by TODO count. Add `--since <ref>` to see the trend of added and removed items over time.
+
 **`todox check`**
 
 Without enforcement, TODO debt grows silently until it becomes unmanageable. `todox check` acts as a CI gate that fails the build when TODO counts exceed a threshold, forbidden tags appear, too many new TODOs are introduced, or deadlines have expired. Run `todox check --max 100 --block-tags BUG` in your CI pipeline, or `todox check --expired` to catch overdue TODOs.
@@ -108,6 +112,19 @@ todox diff main --tag FIXME
 
 # JSON output
 todox diff main --format json
+```
+
+### Stats dashboard
+
+```bash
+# Show tag/priority/author/hotspot summary
+todox stats
+
+# Show trend compared to a git ref
+todox stats --since main
+
+# JSON output
+todox stats --format json
 ```
 
 ### CI gate

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,6 +65,11 @@ pub enum Command {
         tag: Vec<String>,
     },
 
+    Stats {
+        #[arg(long)]
+        since: Option<String>,
+    },
+
     Check {
         #[arg(long)]
         max: Option<usize>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -129,6 +129,31 @@ pub struct CheckViolation {
     pub message: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct StatsResult {
+    pub total_items: usize,
+    pub total_files: usize,
+    pub tag_counts: Vec<(Tag, usize)>,
+    pub priority_counts: PriorityCounts,
+    pub author_counts: Vec<(String, usize)>,
+    pub hotspot_files: Vec<(String, usize)>,
+    pub trend: Option<TrendInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PriorityCounts {
+    pub normal: usize,
+    pub high: usize,
+    pub urgent: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrendInfo {
+    pub added: usize,
+    pub removed: usize,
+    pub base_ref: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
     Error,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,204 @@
+use std::collections::HashMap;
+
+use crate::model::*;
+
+pub fn compute_stats(scan: &ScanResult, diff: Option<&DiffResult>) -> StatsResult {
+    let total_items = scan.items.len();
+
+    // Unique file count
+    let mut file_set: HashMap<&str, usize> = HashMap::new();
+    for item in &scan.items {
+        *file_set.entry(item.file.as_str()).or_insert(0) += 1;
+    }
+    let total_files = file_set.len();
+
+    // Tag counts
+    let mut tag_map: HashMap<Tag, usize> = HashMap::new();
+    for item in &scan.items {
+        *tag_map.entry(item.tag).or_insert(0) += 1;
+    }
+    let mut tag_counts: Vec<(Tag, usize)> = tag_map.into_iter().collect();
+    tag_counts.sort_by(|a, b| b.1.cmp(&a.1));
+
+    // Priority counts
+    let mut normal = 0;
+    let mut high = 0;
+    let mut urgent = 0;
+    for item in &scan.items {
+        match item.priority {
+            Priority::Normal => normal += 1,
+            Priority::High => high += 1,
+            Priority::Urgent => urgent += 1,
+        }
+    }
+    let priority_counts = PriorityCounts {
+        normal,
+        high,
+        urgent,
+    };
+
+    // Author counts
+    let mut author_map: HashMap<String, usize> = HashMap::new();
+    for item in &scan.items {
+        let key = item
+            .author
+            .clone()
+            .unwrap_or_else(|| "unassigned".to_string());
+        *author_map.entry(key).or_insert(0) += 1;
+    }
+    let mut author_counts: Vec<(String, usize)> = author_map.into_iter().collect();
+    author_counts.sort_by(|a, b| b.1.cmp(&a.1));
+
+    // Hotspot files (top 5 by count)
+    let mut hotspot_files: Vec<(String, usize)> = file_set
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+    hotspot_files.sort_by(|a, b| b.1.cmp(&a.1));
+    hotspot_files.truncate(5);
+
+    // Trend info from diff
+    let trend = diff.map(|d| TrendInfo {
+        added: d.added_count,
+        removed: d.removed_count,
+        base_ref: d.base_ref.clone(),
+    });
+
+    StatsResult {
+        total_items,
+        total_files,
+        tag_counts,
+        priority_counts,
+        author_counts,
+        hotspot_files,
+        trend,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Priority, Tag};
+
+    fn make_item(file: &str, line: usize, tag: Tag, message: &str) -> TodoItem {
+        TodoItem {
+            file: file.to_string(),
+            line,
+            tag,
+            message: message.to_string(),
+            author: None,
+            issue_ref: None,
+            priority: Priority::Normal,
+            deadline: None,
+        }
+    }
+
+    #[test]
+    fn test_basic_counts() {
+        let scan = ScanResult {
+            items: vec![
+                make_item("a.rs", 1, Tag::Todo, "task one"),
+                make_item("a.rs", 2, Tag::Todo, "task two"),
+                make_item("b.rs", 1, Tag::Fixme, "fix this"),
+            ],
+            files_scanned: 2,
+        };
+
+        let result = compute_stats(&scan, None);
+        assert_eq!(result.total_items, 3);
+        assert_eq!(result.total_files, 2);
+        assert_eq!(result.tag_counts.len(), 2);
+        assert!(result.trend.is_none());
+    }
+
+    #[test]
+    fn test_priority_counts() {
+        let mut items = vec![
+            make_item("a.rs", 1, Tag::Todo, "normal"),
+            make_item("a.rs", 2, Tag::Todo, "high"),
+            make_item("a.rs", 3, Tag::Todo, "urgent"),
+        ];
+        items[1].priority = Priority::High;
+        items[2].priority = Priority::Urgent;
+
+        let scan = ScanResult {
+            items,
+            files_scanned: 1,
+        };
+
+        let result = compute_stats(&scan, None);
+        assert_eq!(result.priority_counts.normal, 1);
+        assert_eq!(result.priority_counts.high, 1);
+        assert_eq!(result.priority_counts.urgent, 1);
+    }
+
+    #[test]
+    fn test_author_counts() {
+        let mut items = vec![
+            make_item("a.rs", 1, Tag::Todo, "alice task"),
+            make_item("a.rs", 2, Tag::Todo, "bob task"),
+            make_item("a.rs", 3, Tag::Todo, "no author"),
+        ];
+        items[0].author = Some("alice".to_string());
+        items[1].author = Some("bob".to_string());
+
+        let scan = ScanResult {
+            items,
+            files_scanned: 1,
+        };
+
+        let result = compute_stats(&scan, None);
+        assert_eq!(result.author_counts.len(), 3);
+    }
+
+    #[test]
+    fn test_hotspot_files_limited_to_5() {
+        let items: Vec<TodoItem> = (0..10)
+            .map(|i| make_item(&format!("file{}.rs", i), 1, Tag::Todo, "task"))
+            .collect();
+
+        let scan = ScanResult {
+            items,
+            files_scanned: 10,
+        };
+
+        let result = compute_stats(&scan, None);
+        assert_eq!(result.hotspot_files.len(), 5);
+    }
+
+    #[test]
+    fn test_trend_from_diff() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Todo, "task")],
+            files_scanned: 1,
+        };
+        let diff = DiffResult {
+            entries: vec![],
+            added_count: 3,
+            removed_count: 1,
+            base_ref: "main".to_string(),
+        };
+
+        let result = compute_stats(&scan, Some(&diff));
+        assert!(result.trend.is_some());
+        let trend = result.trend.unwrap();
+        assert_eq!(trend.added, 3);
+        assert_eq!(trend.removed, 1);
+        assert_eq!(trend.base_ref, "main");
+    }
+
+    #[test]
+    fn test_empty_scan() {
+        let scan = ScanResult {
+            items: vec![],
+            files_scanned: 0,
+        };
+
+        let result = compute_stats(&scan, None);
+        assert_eq!(result.total_items, 0);
+        assert_eq!(result.total_files, 0);
+        assert!(result.tag_counts.is_empty());
+        assert!(result.author_counts.is_empty());
+        assert!(result.hotspot_files.is_empty());
+    }
+}

--- a/tests/integration_stats.rs
+++ b/tests/integration_stats.rs
@@ -1,0 +1,132 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn todox() -> Command {
+    Command::cargo_bin("todox").unwrap()
+}
+
+fn setup_project(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    for (path, content) in files {
+        let full_path = dir.path().join(path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(full_path, content).unwrap();
+    }
+    dir
+}
+
+#[test]
+fn test_stats_basic_output() {
+    let dir = setup_project(&[
+        (
+            "main.rs",
+            "// TODO: implement feature\n// FIXME: broken\n// TODO: another task\n",
+        ),
+        ("lib.rs", "// HACK: workaround\n"),
+    ]);
+
+    todox()
+        .args(["stats", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tags"))
+        .stdout(predicate::str::contains("TODO"))
+        .stdout(predicate::str::contains("FIXME"))
+        .stdout(predicate::str::contains("HACK"))
+        .stdout(predicate::str::contains("4 items across 2 files"));
+}
+
+#[test]
+fn test_stats_priority_counts() {
+    let dir = setup_project(&[(
+        "main.rs",
+        "// TODO!!: urgent task\n// TODO!: high task\n// TODO: normal task\n",
+    )]);
+
+    todox()
+        .args(["stats", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("normal: 1"))
+        .stdout(predicate::str::contains("high: 1"))
+        .stdout(predicate::str::contains("urgent: 1"));
+}
+
+#[test]
+fn test_stats_with_authors() {
+    let dir = setup_project(&[(
+        "main.rs",
+        "// TODO(alice): alice task\n// TODO(bob): bob task\n// TODO: no author\n",
+    )]);
+
+    todox()
+        .args(["stats", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Authors"))
+        .stdout(predicate::str::contains("alice"))
+        .stdout(predicate::str::contains("bob"))
+        .stdout(predicate::str::contains("unassigned"));
+}
+
+#[test]
+fn test_stats_hotspot_files() {
+    let dir = setup_project(&[
+        ("main.rs", "// TODO: one\n// TODO: two\n// TODO: three\n"),
+        ("lib.rs", "// TODO: single\n"),
+    ]);
+
+    todox()
+        .args(["stats", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Hotspots"))
+        .stdout(predicate::str::contains("main.rs (3)"))
+        .stdout(predicate::str::contains("lib.rs (1)"));
+}
+
+#[test]
+fn test_stats_json_format() {
+    let dir = setup_project(&[("main.rs", "// TODO: json test\n// FIXME: another\n")]);
+
+    todox()
+        .args([
+            "stats",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"total_items\": 2"))
+        .stdout(predicate::str::contains("\"total_files\": 1"))
+        .stdout(predicate::str::contains("\"tag_counts\""))
+        .stdout(predicate::str::contains("\"priority_counts\""));
+}
+
+#[test]
+fn test_stats_empty_project() {
+    let dir = setup_project(&[("main.rs", "fn main() {}\n")]);
+
+    todox()
+        .args(["stats", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 items across 0 files"));
+}
+
+#[test]
+fn test_stats_bar_chart_present() {
+    let dir = setup_project(&[("main.rs", "// TODO: one\n// TODO: two\n// FIXME: three\n")]);
+
+    todox()
+        .args(["stats", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\u{2588}"));
+}


### PR DESCRIPTION
## Summary

- Add `todox stats` subcommand with tag, priority, author, and hotspot file breakdowns
- Render horizontal bar charts (█ blocks) in text output for visual distribution
- Support `--since <ref>` flag for trend data (added/removed counts from git diff)
- JSON output via `--format json`; other formats fall back to JSON

Closes #7

## Test Plan

- [x] Unit tests for `compute_stats()` in `src/stats.rs` (6 tests: basic counts, priority, authors, hotspot limit, trend from diff, empty scan)
- [x] Integration tests in `tests/integration_stats.rs` (7 tests: basic output, priority counts, authors, hotspots, JSON format, empty project, bar chart presence)
- [x] `cargo test` — all 169 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no warnings