### PR TITLE
Add coverage badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,16 @@ jobs:
       - name: Run tests with coverage
         run: cargo llvm-cov --ignore-run-fail --summary-only --fail-under-lines 88
 
+      - name: Generate coverage report (lcov)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: cargo llvm-cov --ignore-run-fail --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+
       - name: Build release
         run: cargo build --release
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # todox
 
-[![CI](https://github.com/sotayamashita/todox/actions/workflows/ci.yml/badge.svg)](https://github.com/sotayamashita/todox/actions/workflows/ci.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sotayamashita/todox)
+[![CI](https://github.com/sotayamashita/todox/actions/workflows/ci.yml/badge.svg)](https://github.com/sotayamashita/todox/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/sotayamashita/todox/graph/badge.svg)](https://codecov.io/gh/sotayamashita/todox) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sotayamashita/todox)
 
 > [!WARNING]
 > **This is an experiment.** This repository exists to explore what AI can and cannot do across the entire software development lifecycle — and where human judgment remains essential. All code, issues, discussions, pull requests, and code reviews are authored and managed exclusively by [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with no human review. Use this project at your own risk. The maintainers assume no responsibility for any issues arising from its use.


### PR DESCRIPTION
Add Codecov integration to CI workflow and coverage badge to README. The lcov report is generated and uploaded to Codecov on main branch pushes, enabling a live coverage badge in the project README.

https://claude.ai/code/session_014ZeA9GGe9Z5uaEsNmaguCM