### PR TITLE
feat(cli): add init and completions subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -134,6 +134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +172,20 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -201,10 +223,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -219,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -517,7 +558,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -588,6 +629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,7 +661,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -625,11 +672,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -671,7 +738,9 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "colored",
+ "dialoguer",
  "globset",
  "ignore",
  "predicates",
@@ -679,9 +748,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -693,11 +763,17 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -706,6 +782,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
 ]
 
 [[package]]
@@ -718,6 +806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "toml_writer"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +822,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -818,7 +918,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -826,6 +926,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -837,10 +946,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -929,6 +1105,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ serde_json = "1"
 toml = "1.0"
 colored = "3"
 anyhow = "1"
+dialoguer = "0.11"
+clap_complete = "4"
+toml_edit = "0.22"
 thiserror = "2"
 time = { version = "0.3", features = ["local-offset"] }
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Without enforcement, TODO debt grows silently until it becomes unmanageable. `to
 
 TODO lists show file:line references but lack surrounding code, forcing you to open files to understand what each TODO refers to. `todox context` displays the code around a specific line with related TODOs in the same file, and the `-C N` flag on `list` and `diff` adds inline context to every item. Run `todox context src/main.rs:25` or `todox list -C 3` to see code in context.
 
+**`todox init`**
+
+New users must manually create `.todox.toml` from documentation, slowing onboarding. `todox init` walks you through an interactive setup that detects your project type (Rust, Node, Go, Python), suggests appropriate exclude directories, and lets you choose which tags to track. Run `todox init` for interactive mode or `todox init --yes` to accept defaults.
+
+**`todox completions <shell>`**
+
+Shell completions are table stakes for CLI tools but require manual setup. `todox completions` generates completion scripts for bash, zsh, fish, elvish, and PowerShell and outputs them to stdout for easy installation. Run `todox completions fish > ~/.config/fish/completions/todox.fish` to install.
+
 **CI-ready output formats**
 
 Plain text output requires extra tooling to integrate with CI dashboards and PR workflows. todox supports `--format github-actions` for inline PR annotations, `--format sarif` for GitHub's [Code Scanning](https://docs.github.com/en/code-security/code-scanning) tab via SARIF (Static Analysis Results Interchange Format), and `--format markdown` for PR comment bot tables. Add `--format github-actions` to any command to get started.
@@ -194,9 +202,32 @@ todox list --format sarif > results.sarif
 todox diff main --format markdown
 ```
 
+### Quick start
+
+```bash
+# Interactive setup — generates .todox.toml
+todox init
+
+# Non-interactive with defaults
+todox init --yes
+```
+
+### Shell completions
+
+```bash
+# Bash
+todox completions bash > ~/.local/share/bash-completion/completions/todox
+
+# Zsh
+todox completions zsh > ~/.zfunc/_todox
+
+# Fish
+todox completions fish > ~/.config/fish/completions/todox.fish
+```
+
 ## Configuration
 
-Create a `.todox.toml` in your project root. The file is discovered by searching upward from the current directory.
+Create a `.todox.toml` in your project root (or run `todox init`). The file is discovered by searching upward from the current directory.
 
 ```toml
 # Tags to scan for (default: all supported tags)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 use std::path::PathBuf;
 
 use crate::model;
@@ -81,6 +82,20 @@ pub enum Command {
         /// Number of context lines (default: 5)
         #[arg(short = 'C', long, default_value = "5")]
         context: usize,
+    },
+
+    /// Generate a .todox.toml configuration file
+    Init {
+        /// Accept defaults without interactive prompts
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: Shell,
     },
 
     Stats {

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+
+use crate::cli::Cli;
+
+pub fn cmd_completions(shell: Shell) -> Result<()> {
+    let mut cmd = Cli::command();
+    let name = cmd.get_name().to_string();
+    generate(shell, &mut cmd, name, &mut std::io::stdout());
+    Ok(())
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,264 @@
+use std::path::Path;
+
+use anyhow::{bail, Result};
+use dialoguer::{Confirm, Input, MultiSelect};
+use toml_edit::{Array, DocumentMut, Item, Table, Value};
+
+const ALL_TAGS: &[&str] = &["TODO", "FIXME", "HACK", "XXX", "BUG", "NOTE"];
+
+struct ProjectHint {
+    name: &'static str,
+    exclude_dirs: Vec<&'static str>,
+}
+
+fn detect_projects(root: &Path) -> Vec<ProjectHint> {
+    let mut hints = Vec::new();
+
+    if root.join("Cargo.toml").exists() {
+        hints.push(ProjectHint {
+            name: "Rust",
+            exclude_dirs: vec!["target"],
+        });
+    }
+    if root.join("package.json").exists() {
+        hints.push(ProjectHint {
+            name: "JavaScript/TypeScript",
+            exclude_dirs: vec!["node_modules", "dist", ".next"],
+        });
+    }
+    if root.join("go.mod").exists() {
+        hints.push(ProjectHint {
+            name: "Go",
+            exclude_dirs: vec!["vendor"],
+        });
+    }
+    if root.join("pyproject.toml").exists() || root.join("requirements.txt").exists() {
+        hints.push(ProjectHint {
+            name: "Python",
+            exclude_dirs: vec![".venv", "__pycache__", ".tox"],
+        });
+    }
+
+    hints
+}
+
+fn collect_suggested_dirs(hints: &[ProjectHint]) -> Vec<&'static str> {
+    let mut dirs = Vec::new();
+    for hint in hints {
+        for dir in &hint.exclude_dirs {
+            if !dirs.contains(dir) {
+                dirs.push(dir);
+            }
+        }
+    }
+    dirs
+}
+
+pub fn cmd_init(root: &Path, non_interactive: bool) -> Result<()> {
+    let config_path = root.join(".todox.toml");
+
+    // Check for existing config
+    if config_path.exists() {
+        if non_interactive {
+            bail!(".todox.toml already exists. Use interactive mode to overwrite.");
+        }
+        let overwrite = Confirm::new()
+            .with_prompt(".todox.toml already exists. Overwrite?")
+            .default(false)
+            .interact()?;
+        if !overwrite {
+            eprintln!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Detect project types
+    let hints = detect_projects(root);
+    if !hints.is_empty() {
+        let names: Vec<&str> = hints.iter().map(|h| h.name).collect();
+        eprintln!("Detected project type(s): {}", names.join(", "));
+    }
+
+    // Select tags
+    let selected_tags: Vec<String> = if non_interactive {
+        ALL_TAGS.iter().map(|s| s.to_string()).collect()
+    } else {
+        let defaults: Vec<bool> = vec![true; ALL_TAGS.len()];
+        let indices = MultiSelect::new()
+            .with_prompt("Select tags to track")
+            .items(ALL_TAGS)
+            .defaults(&defaults)
+            .interact()?;
+        indices.iter().map(|&i| ALL_TAGS[i].to_string()).collect()
+    };
+
+    // Select exclude dirs
+    let suggested_dirs = collect_suggested_dirs(&hints);
+    let selected_dirs: Vec<String> = if non_interactive {
+        suggested_dirs.iter().map(|s| s.to_string()).collect()
+    } else if suggested_dirs.is_empty() {
+        Vec::new()
+    } else {
+        let defaults: Vec<bool> = vec![true; suggested_dirs.len()];
+        let indices = MultiSelect::new()
+            .with_prompt("Select directories to exclude")
+            .items(&suggested_dirs)
+            .defaults(&defaults)
+            .interact()?;
+        indices
+            .iter()
+            .map(|&i| suggested_dirs[i].to_string())
+            .collect()
+    };
+
+    // CI check max
+    let check_max: Option<usize> = if non_interactive {
+        None
+    } else {
+        let want_max = Confirm::new()
+            .with_prompt("Set a maximum TODO count for CI checks?")
+            .default(false)
+            .interact()?;
+        if want_max {
+            let max: usize = Input::new()
+                .with_prompt("Maximum TODO count")
+                .default(100)
+                .interact()?;
+            Some(max)
+        } else {
+            None
+        }
+    };
+
+    // Generate TOML
+    let content = build_config_toml(&selected_tags, &selected_dirs, check_max);
+    std::fs::write(&config_path, content)?;
+
+    eprintln!("Created .todox.toml");
+    eprintln!("Try it out: todox list");
+    Ok(())
+}
+
+fn build_config_toml(tags: &[String], exclude_dirs: &[String], check_max: Option<usize>) -> String {
+    let mut doc = DocumentMut::new();
+
+    // tags
+    let mut tag_array = Array::new();
+    for tag in tags {
+        tag_array.push(tag.as_str());
+    }
+    doc["tags"] = Item::Value(Value::Array(tag_array));
+
+    // exclude_dirs
+    let mut dir_array = Array::new();
+    for dir in exclude_dirs {
+        dir_array.push(dir.as_str());
+    }
+    doc["exclude_dirs"] = Item::Value(Value::Array(dir_array));
+
+    // [check] section
+    if let Some(max) = check_max {
+        let mut check_table = Table::new();
+        check_table["max"] = Item::Value(Value::from(max as i64));
+        doc["check"] = Item::Table(check_table);
+    }
+
+    doc.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_rust_project() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]").unwrap();
+        let hints = detect_projects(dir.path());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].name, "Rust");
+        assert!(hints[0].exclude_dirs.contains(&"target"));
+    }
+
+    #[test]
+    fn test_detect_node_project() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        let hints = detect_projects(dir.path());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].name, "JavaScript/TypeScript");
+        assert!(hints[0].exclude_dirs.contains(&"node_modules"));
+    }
+
+    #[test]
+    fn test_detect_go_project() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "module example").unwrap();
+        let hints = detect_projects(dir.path());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].name, "Go");
+    }
+
+    #[test]
+    fn test_detect_python_project() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("pyproject.toml"), "[tool]").unwrap();
+        let hints = detect_projects(dir.path());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].name, "Python");
+    }
+
+    #[test]
+    fn test_detect_no_project() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let hints = detect_projects(dir.path());
+        assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn test_collect_suggested_dirs_deduplicates() {
+        let hints = vec![
+            ProjectHint {
+                name: "A",
+                exclude_dirs: vec!["dist"],
+            },
+            ProjectHint {
+                name: "B",
+                exclude_dirs: vec!["dist", "vendor"],
+            },
+        ];
+        let dirs = collect_suggested_dirs(&hints);
+        assert_eq!(dirs, vec!["dist", "vendor"]);
+    }
+
+    #[test]
+    fn test_build_config_toml_basic() {
+        let tags = vec!["TODO".to_string(), "FIXME".to_string()];
+        let dirs = vec!["target".to_string()];
+        let content = build_config_toml(&tags, &dirs, None);
+        assert!(content.contains("TODO"));
+        assert!(content.contains("FIXME"));
+        assert!(content.contains("target"));
+        assert!(!content.contains("[check]"));
+    }
+
+    #[test]
+    fn test_build_config_toml_with_check_max() {
+        let tags = vec!["TODO".to_string()];
+        let dirs = vec![];
+        let content = build_config_toml(&tags, &dirs, Some(50));
+        assert!(content.contains("[check]"));
+        assert!(content.contains("max = 50"));
+    }
+
+    #[test]
+    fn test_build_config_toml_parseable() {
+        let tags = vec!["TODO".to_string(), "FIXME".to_string()];
+        let dirs = vec!["target".to_string(), "node_modules".to_string()];
+        let content = build_config_toml(&tags, &dirs, Some(100));
+        let parsed: crate::config::Config = toml::from_str(&content).unwrap();
+        assert_eq!(parsed.tags, vec!["TODO", "FIXME"]);
+        assert_eq!(parsed.exclude_dirs, vec!["target", "node_modules"]);
+        assert_eq!(parsed.check.max, Some(100));
+    }
+}

--- a/tests/integration_completions.rs
+++ b/tests/integration_completions.rs
@@ -1,0 +1,33 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn todox() -> Command {
+    Command::cargo_bin("todox").unwrap()
+}
+
+#[test]
+fn test_completions_bash() {
+    todox()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("todox"));
+}
+
+#[test]
+fn test_completions_zsh() {
+    todox()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("todox"));
+}
+
+#[test]
+fn test_completions_fish() {
+    todox()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete -c todox"));
+}

--- a/tests/integration_init.rs
+++ b/tests/integration_init.rs
@@ -1,0 +1,105 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn todox() -> Command {
+    Command::cargo_bin("todox").unwrap()
+}
+
+#[test]
+fn test_init_creates_config() {
+    let dir = TempDir::new().unwrap();
+
+    todox()
+        .args(["init", "--yes", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Created .todox.toml"));
+
+    let config_path = dir.path().join(".todox.toml");
+    assert!(config_path.exists());
+
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert!(content.contains("TODO"));
+    assert!(content.contains("FIXME"));
+    assert!(content.contains("HACK"));
+
+    // Verify parseable as valid config
+    let _: toml::Value = toml::from_str(&content).unwrap();
+}
+
+#[test]
+fn test_init_refuses_overwrite_in_non_interactive() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(".todox.toml"), "tags = [\"TODO\"]").unwrap();
+
+    todox()
+        .args(["init", "--yes", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
+fn test_init_detects_rust_project() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\n",
+    )
+    .unwrap();
+
+    todox()
+        .args(["init", "--yes", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Rust"));
+
+    let content = fs::read_to_string(dir.path().join(".todox.toml")).unwrap();
+    assert!(content.contains("target"));
+}
+
+#[test]
+fn test_init_detects_node_project() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("package.json"), "{}").unwrap();
+
+    todox()
+        .args(["init", "--yes", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("JavaScript"));
+
+    let content = fs::read_to_string(dir.path().join(".todox.toml")).unwrap();
+    assert!(content.contains("node_modules"));
+}
+
+#[test]
+fn test_init_empty_project_no_exclude_dirs() {
+    let dir = TempDir::new().unwrap();
+
+    todox()
+        .args(["init", "--yes", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(dir.path().join(".todox.toml")).unwrap();
+    // exclude_dirs should be an empty array
+    assert!(content.contains("exclude_dirs = []"));
+}
+
+#[test]
+fn test_init_config_has_all_default_tags() {
+    let dir = TempDir::new().unwrap();
+
+    todox()
+        .args(["init", "--yes", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(dir.path().join(".todox.toml")).unwrap();
+    for tag in &["TODO", "FIXME", "HACK", "XXX", "BUG", "NOTE"] {
+        assert!(content.contains(tag), "missing tag: {}", tag);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `todox init` for interactive `.todox.toml` config generation with project type detection (Rust, Node, Go, Python) and `--yes` flag for non-interactive/CI usage
- Add `todox completions <shell>` for shell completion script output (bash, zsh, fish, elvish, powershell)
- Update README with feature descriptions and usage examples

Closes #8

## Test Plan

- [x] Unit tests for project detection, TOML generation, and config parseability (`src/init.rs`)
- [x] Integration tests for `todox init --yes` with project detection (`tests/integration_init.rs` — 6 tests)
- [x] Integration tests for `todox completions` bash/zsh/fish output (`tests/integration_completions.rs` — 3 tests)
- [x] All 137 existing tests continue to pass
- [x] Manual testing: `todox init --yes`, `todox completions fish`