### PR TITLE
chore: add .todox.toml to exclude test/doc files from TODO gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo build --release
 
       - name: TODO gate
-        run: cargo run --release -- check --max 225
+        run: cargo run --release -- check --max 100
 
       - name: TODO diff (PR only)
         if: github.event_name == 'pull_request'

--- a/.todox.toml
+++ b/.todox.toml
@@ -1,0 +1,21 @@
+# Tags to scan for (default: all supported tags)
+tags = ["TODO", "FIXME", "HACK", "XXX", "BUG", "NOTE"]
+
+# Directories to exclude from scanning
+# - tests/ contains TODO strings as test fixture data, not actionable TODOs
+# - docs/ contains workflow docs referencing TODO patterns
+exclude_dirs = ["target", "tests", "docs"]
+
+# Regex patterns to exclude files
+# - README.md contains TODO examples in documentation
+# - CLAUDE.md contains project instructions referencing TODO patterns
+exclude_patterns = [
+    "README\\.md$",
+    "CLAUDE\\.md$",
+]
+
+[check]
+max = 100
+
+[blame]
+stale_threshold = "365d"


### PR DESCRIPTION
## Summary

- Add `.todox.toml` config to exclude non-actionable TODO patterns from scanning
  - `exclude_dirs`: `tests`, `docs` (test fixture data and workflow docs)
  - `exclude_patterns`: `README.md`, `CLAUDE.md` (documentation examples)
- Revert CI TODO gate threshold from 225 back to 100 (actual source TODOs: 59)

The blame feature (#5) added TODO pattern strings in test fixtures and README examples, inflating the count from ~182 to 204 and forcing a workaround threshold of 225. This PR fixes the root cause by excluding non-actionable files.

Closes #61

## Test Plan

- [x] `cargo test` — all 230 tests pass
- [x] `cargo run -- check --max 100` — passes (59 TODOs in source)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean