### PR TITLE
docs(config): add configuration reference table and JSON schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +577,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +630,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -745,6 +786,7 @@ dependencies = [
  "ignore",
  "predicates",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.0"
+schemars = { version = "0.8", features = ["derive"] }
 colored = "3"
 anyhow = "1"
 dialoguer = "0.11"

--- a/README.md
+++ b/README.md
@@ -289,6 +289,33 @@ stale_threshold = "180d"
 
 All fields are optional. Unspecified values use sensible defaults.
 
+A machine-readable JSON Schema is available at [`schema/todox.schema.json`](schema/todox.schema.json) for editor validation and autocompletion (e.g., [Taplo](https://taplo.tamasfe.dev/), [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)).
+
+### Configuration Reference
+
+#### Top-level fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `tags` | `string[]` | `["TODO","FIXME","HACK","XXX","BUG","NOTE"]` | Tag keywords to scan for |
+| `exclude_dirs` | `string[]` | `[]` | Directory names to skip during scanning |
+| `exclude_patterns` | `string[]` | `[]` | Regex patterns; matching file paths are excluded |
+
+#### `[check]` section
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max` | `integer` | _(none)_ | Maximum total TODOs allowed |
+| `max_new` | `integer` | _(none)_ | Maximum new TODOs allowed (requires `--since`) |
+| `block_tags` | `string[]` | `[]` | Tags that cause `check` to fail immediately |
+| `expired` | `boolean` | _(none)_ | Fail if any TODOs have expired deadlines |
+
+#### `[blame]` section
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `stale_threshold` | `string` | `"365d"` | Duration threshold for marking TODOs as stale |
+
 ## Agent Skill
 
 todox provides a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) that enables AI coding agents to automatically use todox commands for TODO tracking, CI gate configuration, and code quality checks.

--- a/schema/todox.schema.json
+++ b/schema/todox.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "todox Configuration",
+  "description": "Configuration for todox TODO tracking tool",
+  "type": "object",
+  "properties": {
+    "blame": {
+      "description": "Git blame analysis settings",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlameConfig"
+        }
+      ]
+    },
+    "check": {
+      "description": "CI gate check settings",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CheckConfig"
+        }
+      ]
+    },
+    "exclude_dirs": {
+      "description": "Directory names to skip during scanning",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "exclude_patterns": {
+      "description": "Regex patterns; matching file paths are excluded",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tags": {
+      "description": "Tags to scan for (e.g., TODO, FIXME, HACK)",
+      "default": [
+        "TODO",
+        "FIXME",
+        "HACK",
+        "XXX",
+        "BUG",
+        "NOTE"
+      ],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "BlameConfig": {
+      "description": "Git blame analysis settings",
+      "type": "object",
+      "properties": {
+        "stale_threshold": {
+          "description": "Duration threshold for marking TODOs as stale (e.g., \"180d\")",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CheckConfig": {
+      "description": "CI gate check settings",
+      "type": "object",
+      "properties": {
+        "block_tags": {
+          "description": "Tags that cause check to fail immediately",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "expired": {
+          "description": "Fail if any TODOs have expired deadlines",
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "max": {
+          "description": "Maximum total TODOs allowed",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "max_new": {
+          "description": "Maximum new TODOs allowed (requires --since)",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `schemars` dependency and derive `JsonSchema` on `Config`, `CheckConfig`, `BlameConfig` structs to auto-generate `schema/todox.schema.json`
- Add `schema_is_up_to_date` unit test that fails when the committed schema drifts from the structs (regenerate with `UPDATE_SCHEMA=1 cargo test schema_is_up_to_date`)
- Add configuration reference tables to README (top-level, `[check]`, `[blame]` sections) with types, defaults, and descriptions
- Link to the JSON Schema file for editor validation/autocompletion (Taplo, Even Better TOML)

Closes #62

## Test Plan

- [x] `cargo test` — all 138 unit + 93 integration tests pass (including new `schema_is_up_to_date`)
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] JSON Schema is valid and auto-generated from structs
- [x] README reference table content verified against `src/config.rs` structs