### PR TITLE
feat(lint): add lint subcommand for TODO formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ TODO comments lack accountability — you can't tell who wrote them or when with
 
 Scrolling through `todox list` output or manually grepping to find specific TODOs is impractical in large codebases with hundreds of items. `todox search` filters TODO comments by message text or issue reference using case-insensitive substring matching, with an `--exact` flag for case-sensitive searches. Run `todox search "migration"` to find relevant items, or combine with `--author`, `--tag`, `--path`, and `-C` context lines for precise results.
 
+**`todox lint`**
+
+TODO comments in team codebases drift in format — inconsistent casing, missing colons, missing authors — degrading scanner reliability and code hygiene. `todox lint` enforces configurable formatting rules (uppercase tags, colons, author attribution, issue references, message length) and exits with code 1 on violations, making it CI-ready out of the box. Run `todox lint` for sensible defaults, or configure rules in `.todox.toml` under `[lint]`.
+
 **`todox check`**
 
 Without enforcement, TODO debt grows silently until it becomes unmanageable. `todox check` acts as a CI gate that fails the build when TODO counts exceed a threshold, forbidden tags appear, too many new TODOs are introduced, or deadlines have expired. Run `todox check --max 100 --block-tags BUG` in your CI pipeline, or `todox check --expired` to catch overdue TODOs.
@@ -218,6 +222,30 @@ todox stats --since main
 todox stats --format json
 ```
 
+### Lint TODO formatting
+
+```bash
+# Check formatting with sensible defaults (uppercase, colon, no bare tags)
+todox lint
+
+# Require author for specific tags
+todox lint --require-author TODO,FIXME
+
+# Require issue reference for BUG tags
+todox lint --require-issue-ref BUG
+
+# Enforce max message length
+todox lint --max-message-length 120
+
+# Combine rules
+todox lint --require-author TODO --require-issue-ref BUG --max-message-length 120
+
+# JSON output
+todox lint --format json
+```
+
+Exit codes: `0` = pass, `1` = fail, `2` = error.
+
 ### CI gate
 
 ```bash
@@ -314,6 +342,25 @@ expired = true
 [blame]
 # Days threshold for marking TODOs as stale (default: 365d)
 stale_threshold = "180d"
+
+[lint]
+# Reject TODOs with empty message (default: true)
+no_bare_tags = true
+
+# Enforce uppercase tag names (default: true)
+uppercase_tag = true
+
+# Enforce colon after tag (default: true)
+require_colon = true
+
+# Enforce max message character count (default: disabled)
+# max_message_length = 120
+
+# Require (author) for specified tags (default: disabled)
+# require_author = ["TODO", "FIXME"]
+
+# Require issue ref for specified tags (default: disabled)
+# require_issue_ref = ["BUG"]
 ```
 
 All fields are optional. Unspecified values use sensible defaults.
@@ -344,6 +391,17 @@ A machine-readable JSON Schema is available at [`schema/todox.schema.json`](sche
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `stale_threshold` | `string` | `"365d"` | Duration threshold for marking TODOs as stale |
+
+#### `[lint]` section
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `no_bare_tags` | `boolean` | `true` | Reject TODOs with empty message |
+| `uppercase_tag` | `boolean` | `true` | Enforce uppercase tag names |
+| `require_colon` | `boolean` | `true` | Enforce colon after tag |
+| `max_message_length` | `integer` | _(none)_ | Enforce max message character count |
+| `require_author` | `string[]` | _(none)_ | Require `(author)` for specified tags |
+| `require_issue_ref` | `string[]` | _(none)_ | Require issue ref for specified tags |
 
 ## Agent Skill
 

--- a/schema/todox.schema.json
+++ b/schema/todox.schema.json
@@ -36,6 +36,14 @@
         "type": "string"
       }
     },
+    "lint": {
+      "description": "Lint rule settings",
+      "allOf": [
+        {
+          "$ref": "#/definitions/LintConfig"
+        }
+      ]
+    },
     "tags": {
       "description": "Tags to scan for (e.g., TODO, FIXME, HACK)",
       "default": [
@@ -108,6 +116,69 @@
           ],
           "format": "uint",
           "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "LintConfig": {
+      "description": "Lint rule settings for TODO comment formatting",
+      "type": "object",
+      "properties": {
+        "max_message_length": {
+          "description": "Enforce max message character count",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "no_bare_tags": {
+          "description": "Reject TODOs with empty message (default: true)",
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "require_author": {
+          "description": "Require (author) for specified tags",
+          "default": null,
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_colon": {
+          "description": "Enforce colon after tag (default: true)",
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "require_issue_ref": {
+          "description": "Require issue ref (#N) for specified tags",
+          "default": null,
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "uppercase_tag": {
+          "description": "Enforce uppercase tag names (default: true)",
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -171,6 +171,33 @@ pub enum Command {
         #[arg(long)]
         expired: bool,
     },
+
+    /// Lint TODO comment formatting against configurable rules
+    Lint {
+        /// Reject TODOs with empty message
+        #[arg(long)]
+        no_bare_tags: bool,
+
+        /// Enforce max message character count
+        #[arg(long)]
+        max_message_length: Option<usize>,
+
+        /// Require (author) for specified tags (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        require_author: Vec<String>,
+
+        /// Require issue ref (#N) for specified tags (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        require_issue_ref: Vec<String>,
+
+        /// Enforce uppercase tag names
+        #[arg(long)]
+        uppercase_tag: bool,
+
+        /// Enforce colon after tag
+        #[arg(long)]
+        require_colon: bool,
+    },
 }
 
 #[derive(Clone, ValueEnum)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub check: CheckConfig,
     /// Git blame analysis settings
     pub blame: BlameConfig,
+    /// Lint rule settings
+    pub lint: LintConfig,
 }
 
 /// CI gate check settings
@@ -44,6 +46,25 @@ pub struct BlameConfig {
     pub stale_threshold: Option<String>,
 }
 
+/// Lint rule settings for TODO comment formatting
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(default)]
+#[schemars(deny_unknown_fields)]
+pub struct LintConfig {
+    /// Reject TODOs with empty message (default: true)
+    pub no_bare_tags: Option<bool>,
+    /// Enforce max message character count
+    pub max_message_length: Option<usize>,
+    /// Require (author) for specified tags
+    pub require_author: Option<Vec<String>>,
+    /// Require issue ref (#N) for specified tags
+    pub require_issue_ref: Option<Vec<String>>,
+    /// Enforce uppercase tag names (default: true)
+    pub uppercase_tag: Option<bool>,
+    /// Enforce colon after tag (default: true)
+    pub require_colon: Option<bool>,
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -59,6 +80,7 @@ impl Default for Config {
             exclude_patterns: vec![],
             check: CheckConfig::default(),
             blame: BlameConfig::default(),
+            lint: LintConfig::default(),
         }
     }
 }
@@ -67,7 +89,7 @@ impl Config {
     /// Build regex pattern from configured tags
     pub fn tags_pattern(&self) -> String {
         let tags = self.tags.join("|");
-        format!(r"(?i)\b({tags})(?:\(([^)]+)\))?:?\s*(!{{1,2}})?\s*(.+)$")
+        format!(r"(?i)\b({tags})(?:\(([^)]+)\))?:?\s*(!{{1,2}})?\s*(.*)$")
     }
 
     /// Load config from .todox.toml, searching up from the given directory

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,0 +1,540 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use regex::Regex;
+
+use crate::config::Config;
+use crate::model::{LintResult, LintViolation, ScanResult, TodoItem};
+use crate::scanner;
+
+pub struct LintOverrides {
+    pub no_bare_tags: bool,
+    pub max_message_length: Option<usize>,
+    pub require_author: Vec<String>,
+    pub require_issue_ref: Vec<String>,
+    pub uppercase_tag: bool,
+    pub require_colon: bool,
+}
+
+struct ResolvedLint {
+    no_bare_tags: bool,
+    max_message_length: Option<usize>,
+    require_author: Vec<String>,
+    require_issue_ref: Vec<String>,
+    uppercase_tag: bool,
+    require_colon: bool,
+}
+
+fn resolve_config(config: &Config, overrides: &LintOverrides) -> ResolvedLint {
+    ResolvedLint {
+        no_bare_tags: overrides.no_bare_tags || config.lint.no_bare_tags.unwrap_or(true),
+        max_message_length: overrides
+            .max_message_length
+            .or(config.lint.max_message_length),
+        require_author: if !overrides.require_author.is_empty() {
+            overrides.require_author.clone()
+        } else {
+            config.lint.require_author.clone().unwrap_or_default()
+        },
+        require_issue_ref: if !overrides.require_issue_ref.is_empty() {
+            overrides.require_issue_ref.clone()
+        } else {
+            config.lint.require_issue_ref.clone().unwrap_or_default()
+        },
+        uppercase_tag: overrides.uppercase_tag || config.lint.uppercase_tag.unwrap_or(true),
+        require_colon: overrides.require_colon || config.lint.require_colon.unwrap_or(true),
+    }
+}
+
+pub fn run_lint(
+    scan: &ScanResult,
+    config: &Config,
+    overrides: &LintOverrides,
+    root: &Path,
+) -> LintResult {
+    let resolved = resolve_config(config, overrides);
+    let mut violations = Vec::new();
+
+    // Phase 1: Metadata-based rules
+    for item in &scan.items {
+        check_metadata_rules(item, &resolved, &mut violations);
+    }
+
+    // Phase 2: Raw-text rules (uppercase_tag, require_colon)
+    if resolved.uppercase_tag || resolved.require_colon {
+        check_raw_text_rules(scan, config, root, &resolved, &mut violations);
+    }
+
+    // Sort by file, then line
+    violations.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
+
+    let violation_count = violations.len();
+    LintResult {
+        passed: violations.is_empty(),
+        total_items: scan.items.len(),
+        violation_count,
+        violations,
+    }
+}
+
+fn check_metadata_rules(
+    item: &TodoItem,
+    resolved: &ResolvedLint,
+    violations: &mut Vec<LintViolation>,
+) {
+    // no_bare_tags
+    if resolved.no_bare_tags && item.message.trim().is_empty() {
+        violations.push(LintViolation {
+            rule: "no_bare_tags".to_string(),
+            message: format!("Empty {} message", item.tag),
+            file: item.file.clone(),
+            line: item.line,
+            suggestion: Some(format!("{}: <description>", item.tag)),
+        });
+    }
+
+    // max_message_length
+    if let Some(max) = resolved.max_message_length {
+        if item.message.len() > max {
+            violations.push(LintViolation {
+                rule: "max_message_length".to_string(),
+                message: format!(
+                    "Message length ({}) exceeds maximum ({})",
+                    item.message.len(),
+                    max
+                ),
+                file: item.file.clone(),
+                line: item.line,
+                suggestion: Some("Shorten the message or raise max_message_length".to_string()),
+            });
+        }
+    }
+
+    // require_author
+    if !resolved.require_author.is_empty() {
+        let tag_str = item.tag.as_str();
+        if resolved
+            .require_author
+            .iter()
+            .any(|t| t.eq_ignore_ascii_case(tag_str))
+            && item.author.is_none()
+        {
+            violations.push(LintViolation {
+                rule: "require_author".to_string(),
+                message: format!("Missing author for {} comment", item.tag),
+                file: item.file.clone(),
+                line: item.line,
+                suggestion: Some(format!("{}(author): <message>", item.tag)),
+            });
+        }
+    }
+
+    // require_issue_ref
+    if !resolved.require_issue_ref.is_empty() {
+        let tag_str = item.tag.as_str();
+        if resolved
+            .require_issue_ref
+            .iter()
+            .any(|t| t.eq_ignore_ascii_case(tag_str))
+            && item.issue_ref.is_none()
+        {
+            violations.push(LintViolation {
+                rule: "require_issue_ref".to_string(),
+                message: format!("Missing issue reference for {} comment", item.tag),
+                file: item.file.clone(),
+                line: item.line,
+                suggestion: Some("Add an issue reference (#123 or JIRA-456)".to_string()),
+            });
+        }
+    }
+}
+
+fn check_raw_text_rules(
+    scan: &ScanResult,
+    config: &Config,
+    root: &Path,
+    resolved: &ResolvedLint,
+    violations: &mut Vec<LintViolation>,
+) {
+    // Group items by file
+    let mut file_items: HashMap<&str, Vec<&TodoItem>> = HashMap::new();
+    for item in &scan.items {
+        file_items.entry(item.file.as_str()).or_default().push(item);
+    }
+
+    // Build regex for raw-text analysis
+    let tags = config.tags.join("|");
+    let raw_re = Regex::new(&format!(r"(?i)\b({})(?:\([^)]*\))?(:)?", tags))
+        .expect("invalid raw lint regex");
+
+    for (file_path, items) in &file_items {
+        let full_path = root.join(file_path);
+        let content = match std::fs::read_to_string(&full_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let lines: Vec<&str> = content.lines().collect();
+
+        for item in items {
+            let line_idx = item.line.saturating_sub(1);
+            if line_idx >= lines.len() {
+                continue;
+            }
+            let line = lines[line_idx];
+
+            // Find the tag occurrence that is inside a comment
+            for caps in raw_re.captures_iter(line) {
+                let tag_match = caps.get(1).unwrap();
+                if !scanner::is_in_comment(line, tag_match.start()) {
+                    continue;
+                }
+
+                // uppercase_tag
+                if resolved.uppercase_tag {
+                    let raw_tag = tag_match.as_str();
+                    let expected = item.tag.as_str();
+                    if raw_tag != expected {
+                        violations.push(LintViolation {
+                            rule: "uppercase_tag".to_string(),
+                            message: format!(
+                                "Tag '{}' should be uppercase '{}'",
+                                raw_tag, expected
+                            ),
+                            file: item.file.clone(),
+                            line: item.line,
+                            suggestion: Some(format!("Change '{}' to '{}'", raw_tag, expected)),
+                        });
+                    }
+                }
+
+                // require_colon
+                if resolved.require_colon && caps.get(2).is_none() {
+                    violations.push(LintViolation {
+                        rule: "require_colon".to_string(),
+                        message: format!("Missing colon after {} tag", item.tag),
+                        file: item.file.clone(),
+                        line: item.line,
+                        suggestion: Some(format!("{}: <message>", item.tag)),
+                    });
+                }
+
+                break; // Only check the first in-comment match
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Priority, Tag};
+
+    fn make_item(file: &str, line: usize, tag: Tag, message: &str) -> TodoItem {
+        TodoItem {
+            file: file.to_string(),
+            line,
+            tag,
+            message: message.to_string(),
+            author: None,
+            issue_ref: None,
+            priority: Priority::Normal,
+            deadline: None,
+        }
+    }
+
+    fn default_overrides() -> LintOverrides {
+        LintOverrides {
+            no_bare_tags: false,
+            max_message_length: None,
+            require_author: vec![],
+            require_issue_ref: vec![],
+            uppercase_tag: false,
+            require_colon: false,
+        }
+    }
+
+    #[test]
+    fn test_no_bare_tags_detects_empty_message() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Todo, "")],
+            files_scanned: 1,
+        };
+        let config = Config::default();
+        let overrides = default_overrides();
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert_eq!(result.violations.len(), 1);
+        assert_eq!(result.violations[0].rule, "no_bare_tags");
+    }
+
+    #[test]
+    fn test_no_bare_tags_allows_non_empty_message() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Todo, "real message")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = default_overrides();
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn test_max_message_length() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Todo, "this is a long message")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            max_message_length: Some(10),
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert_eq!(result.violations[0].rule, "max_message_length");
+    }
+
+    #[test]
+    fn test_require_author_missing() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Todo, "no author")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            require_author: vec!["TODO".to_string()],
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert_eq!(result.violations[0].rule, "require_author");
+    }
+
+    #[test]
+    fn test_require_author_present() {
+        let mut item = make_item("a.rs", 1, Tag::Todo, "has author");
+        item.author = Some("alice".to_string());
+        let scan = ScanResult {
+            items: vec![item],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            require_author: vec!["TODO".to_string()],
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn test_require_issue_ref_missing() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Bug, "no issue ref")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            require_issue_ref: vec!["BUG".to_string()],
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert_eq!(result.violations[0].rule, "require_issue_ref");
+    }
+
+    #[test]
+    fn test_require_issue_ref_present() {
+        let mut item = make_item("a.rs", 1, Tag::Bug, "fix #123");
+        item.issue_ref = Some("#123".to_string());
+        let scan = ScanResult {
+            items: vec![item],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            require_issue_ref: vec!["BUG".to_string()],
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn test_require_author_ignores_unmatched_tags() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Note, "just a note")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            require_author: vec!["TODO".to_string()],
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn test_uppercase_tag_with_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.rs");
+        std::fs::write(&file_path, "// todo: lowercase tag\n").unwrap();
+
+        let scan = ScanResult {
+            items: vec![make_item("test.rs", 1, Tag::Todo, "lowercase tag")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            uppercase_tag: true,
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, dir.path());
+        assert!(!result.passed);
+        assert!(result.violations.iter().any(|v| v.rule == "uppercase_tag"));
+    }
+
+    #[test]
+    fn test_uppercase_tag_passes_for_uppercase() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.rs");
+        std::fs::write(&file_path, "// TODO: uppercase tag\n").unwrap();
+
+        let scan = ScanResult {
+            items: vec![make_item("test.rs", 1, Tag::Todo, "uppercase tag")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            uppercase_tag: true,
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, dir.path());
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn test_require_colon_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.rs");
+        std::fs::write(&file_path, "// TODO fix without colon\n").unwrap();
+
+        let scan = ScanResult {
+            items: vec![make_item("test.rs", 1, Tag::Todo, "fix without colon")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        let overrides = LintOverrides {
+            require_colon: true,
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, dir.path());
+        assert!(!result.passed);
+        assert!(result.violations.iter().any(|v| v.rule == "require_colon"));
+    }
+
+    #[test]
+    fn test_require_colon_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.rs");
+        std::fs::write(&file_path, "// TODO: fix with colon\n").unwrap();
+
+        let scan = ScanResult {
+            items: vec![make_item("test.rs", 1, Tag::Todo, "fix with colon")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        let overrides = LintOverrides {
+            require_colon: true,
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, dir.path());
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn test_config_overrides_defaults() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Todo, "valid message")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        // Disable all default-true rules via config
+        config.lint.no_bare_tags = Some(false);
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = default_overrides();
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn test_cli_overrides_config() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Todo, "")],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.no_bare_tags = Some(false); // Config disables
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            no_bare_tags: true, // CLI enables
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert_eq!(result.violations[0].rule, "no_bare_tags");
+    }
+
+    #[test]
+    fn test_multiple_violations() {
+        let scan = ScanResult {
+            items: vec![
+                make_item("a.rs", 1, Tag::Todo, ""),
+                make_item("a.rs", 2, Tag::Bug, "no issue ref"),
+            ],
+            files_scanned: 1,
+        };
+        let mut config = Config::default();
+        config.lint.uppercase_tag = Some(false);
+        config.lint.require_colon = Some(false);
+        let overrides = LintOverrides {
+            require_issue_ref: vec!["BUG".to_string()],
+            ..default_overrides()
+        };
+        let result = run_lint(&scan, &config, &overrides, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert_eq!(result.violation_count, 2);
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -189,6 +189,23 @@ pub struct SearchResult {
     pub file_count: usize,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct LintViolation {
+    pub rule: String,
+    pub message: String,
+    pub file: String,
+    pub line: usize,
+    pub suggestion: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LintResult {
+    pub passed: bool,
+    pub total_items: usize,
+    pub violation_count: usize,
+    pub violations: Vec<LintViolation>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
     Error,

--- a/src/output/github_actions.rs
+++ b/src/output/github_actions.rs
@@ -103,6 +103,28 @@ pub fn format_blame(result: &BlameResult) -> String {
     lines.join("\n")
 }
 
+pub fn format_lint(result: &LintResult) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    if result.passed {
+        lines.push("::notice::todox lint: PASS".to_string());
+    } else {
+        for violation in &result.violations {
+            let file = escape_property(&violation.file);
+            let msg = escape_message(&violation.message);
+            lines.push(format!(
+                "::error file={file},line={},title={}::{msg}",
+                violation.line, violation.rule
+            ));
+        }
+        lines.push(format!(
+            "::error::todox lint: FAIL ({} violations)",
+            result.violation_count
+        ));
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
+
 pub fn format_check(result: &CheckResult) -> String {
     let mut lines: Vec<String> = Vec::new();
     if result.passed {

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -135,6 +135,43 @@ pub fn format_blame(result: &BlameResult) -> String {
     lines.join("\n")
 }
 
+pub fn format_lint(result: &LintResult) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    if result.passed {
+        lines.push("## PASS".to_string());
+        lines.push(String::new());
+        lines.push(format!(
+            "All lint checks passed ({} items total).",
+            result.total_items
+        ));
+    } else {
+        lines.push("## FAIL".to_string());
+        lines.push(String::new());
+        lines.push("| File | Line | Rule | Message | Suggestion |".to_string());
+        lines.push("|------|------|------|---------|------------|".to_string());
+
+        for v in &result.violations {
+            let file = escape_cell(&v.file);
+            let message = escape_cell(&v.message);
+            let suggestion = v.suggestion.as_deref().map(escape_cell).unwrap_or_default();
+            lines.push(format!(
+                "| {} | {} | {} | {} | {} |",
+                file, v.line, v.rule, message, suggestion
+            ));
+        }
+
+        lines.push(String::new());
+        lines.push(format!(
+            "**{} violations in {} items**",
+            result.violation_count, result.total_items
+        ));
+    }
+
+    lines.push(String::new());
+    lines.join("\n")
+}
+
 pub fn format_check(result: &CheckResult) -> String {
     let mut lines: Vec<String> = Vec::new();
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -86,7 +86,7 @@ fn parse_paren_content(s: &str) -> (Option<String>, Option<Deadline>) {
 }
 
 /// Heuristic: does the tag at `tag_start` appear to be inside a comment?
-fn is_in_comment(line: &str, tag_start: usize) -> bool {
+pub(crate) fn is_in_comment(line: &str, tag_start: usize) -> bool {
     let before_tag = &line[..tag_start];
     if COMMENT_PREFIXES.iter().any(|p| before_tag.contains(p)) {
         return true;

--- a/tests/integration_lint.rs
+++ b/tests/integration_lint.rs
@@ -1,0 +1,508 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn todox() -> Command {
+    Command::cargo_bin("todox").unwrap()
+}
+
+fn setup_project(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    for (path, content) in files {
+        let full_path = dir.path().join(path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(full_path, content).unwrap();
+    }
+    dir
+}
+
+// --- Pass cases ---
+
+#[test]
+fn test_lint_pass_valid_todos() {
+    let dir = setup_project(&[("main.rs", "// TODO: implement this feature\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+#[test]
+fn test_lint_pass_with_author_and_issue() {
+    let dir = setup_project(&[(
+        "main.rs",
+        "// TODO(alice): fix issue #123\n// FIXME(bob): handle edge case JIRA-456\n",
+    )]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--require-author",
+            "TODO,FIXME",
+            "--require-issue-ref",
+            "TODO,FIXME",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+// --- Bare tags ---
+
+#[test]
+fn test_lint_fail_bare_tag() {
+    let dir = setup_project(&[("main.rs", "// TODO:\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"))
+        .stdout(predicate::str::contains("no_bare_tags"));
+}
+
+#[test]
+fn test_lint_fail_bare_tag_no_colon() {
+    let dir = setup_project(&[("main.rs", "// TODO\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"));
+}
+
+// --- Uppercase tag ---
+
+#[test]
+fn test_lint_fail_lowercase_tag() {
+    let dir = setup_project(&[("main.rs", "// todo: lowercase tag\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"))
+        .stdout(predicate::str::contains("uppercase_tag"));
+}
+
+#[test]
+fn test_lint_fail_mixed_case_tag() {
+    let dir = setup_project(&[("main.rs", "// Todo: mixed case\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("uppercase_tag"));
+}
+
+// --- Require colon ---
+
+#[test]
+fn test_lint_fail_missing_colon() {
+    let dir = setup_project(&[("main.rs", "// TODO fix without colon\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"))
+        .stdout(predicate::str::contains("require_colon"));
+}
+
+// --- Require author ---
+
+#[test]
+fn test_lint_fail_missing_author() {
+    let dir = setup_project(&[("main.rs", "// TODO: no author here\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--require-author",
+            "TODO",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"))
+        .stdout(predicate::str::contains("require_author"));
+}
+
+#[test]
+fn test_lint_pass_author_present() {
+    let dir = setup_project(&[("main.rs", "// TODO(alice): has author\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--require-author",
+            "TODO",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+#[test]
+fn test_lint_require_author_ignores_other_tags() {
+    let dir = setup_project(&[("main.rs", "// NOTE: no author needed\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--require-author",
+            "TODO",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+// --- Require issue ref ---
+
+#[test]
+fn test_lint_fail_missing_issue_ref() {
+    let dir = setup_project(&[("main.rs", "// BUG: no issue ref\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--require-issue-ref",
+            "BUG",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"))
+        .stdout(predicate::str::contains("require_issue_ref"));
+}
+
+#[test]
+fn test_lint_pass_issue_ref_present() {
+    let dir = setup_project(&[("main.rs", "// BUG: fix crash #42\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--require-issue-ref",
+            "BUG",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+// --- Max message length ---
+
+#[test]
+fn test_lint_fail_message_too_long() {
+    let dir = setup_project(&[(
+        "main.rs",
+        "// TODO: this is a very long message that exceeds the limit\n",
+    )]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--max-message-length",
+            "10",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"))
+        .stdout(predicate::str::contains("max_message_length"));
+}
+
+#[test]
+fn test_lint_pass_message_within_limit() {
+    let dir = setup_project(&[("main.rs", "// TODO: short\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--max-message-length",
+            "100",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+// --- Output formats ---
+
+#[test]
+fn test_lint_json_format_pass() {
+    let dir = setup_project(&[("main.rs", "// TODO: valid task\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"passed\": true"))
+        .stdout(predicate::str::contains("\"violation_count\": 0"));
+}
+
+#[test]
+fn test_lint_json_format_fail() {
+    let dir = setup_project(&[("main.rs", "// todo: lowercase\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"passed\": false"))
+        .stdout(predicate::str::contains("\"rule\": \"uppercase_tag\""));
+}
+
+#[test]
+fn test_lint_github_actions_format_pass() {
+    let dir = setup_project(&[("main.rs", "// TODO: valid task\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "github-actions",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("::notice::todox lint: PASS"));
+}
+
+#[test]
+fn test_lint_github_actions_format_fail() {
+    let dir = setup_project(&[("main.rs", "// todo: lowercase\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "github-actions",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "::error file=main.rs,line=1,title=uppercase_tag",
+        ))
+        .stdout(predicate::str::contains("::error::todox lint: FAIL"));
+}
+
+#[test]
+fn test_lint_sarif_format_pass() {
+    let dir = setup_project(&[("main.rs", "// TODO: valid task\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "sarif",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"version\": \"2.1.0\""))
+        .stdout(predicate::str::contains("\"level\": \"note\""));
+}
+
+#[test]
+fn test_lint_sarif_format_fail() {
+    let dir = setup_project(&[("main.rs", "// todo: lowercase\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "sarif",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("todox/lint/uppercase_tag"))
+        .stdout(predicate::str::contains("\"level\": \"error\""));
+}
+
+#[test]
+fn test_lint_markdown_format_pass() {
+    let dir = setup_project(&[("main.rs", "// TODO: valid task\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "markdown",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("## PASS"))
+        .stdout(predicate::str::contains("All lint checks passed"));
+}
+
+#[test]
+fn test_lint_markdown_format_fail() {
+    let dir = setup_project(&[("main.rs", "// todo: lowercase\n")]);
+
+    todox()
+        .args([
+            "lint",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "markdown",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("## FAIL"))
+        .stdout(predicate::str::contains("uppercase_tag"));
+}
+
+// --- Config file integration ---
+
+#[test]
+fn test_lint_config_file_require_author() {
+    let dir = setup_project(&[
+        ("main.rs", "// TODO: no author\n"),
+        (
+            ".todox.toml",
+            r#"
+[lint]
+require_author = ["TODO"]
+"#,
+        ),
+    ]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("require_author"));
+}
+
+#[test]
+fn test_lint_config_file_disable_defaults() {
+    let dir = setup_project(&[
+        ("main.rs", "// todo fix something\n"),
+        (
+            ".todox.toml",
+            r#"
+[lint]
+no_bare_tags = false
+uppercase_tag = false
+require_colon = false
+"#,
+        ),
+    ]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+// --- Multiple violations ---
+
+#[test]
+fn test_lint_multiple_violations_same_file() {
+    let dir = setup_project(&[(
+        "main.rs",
+        "// todo fix something\n// FIXME no colon either\n",
+    )]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"));
+}
+
+// --- Exit code verification ---
+
+#[test]
+fn test_lint_exit_code_0_on_pass() {
+    let dir = setup_project(&[("main.rs", "// TODO: valid task\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn test_lint_exit_code_1_on_fail() {
+    let dir = setup_project(&[("main.rs", "// todo: lowercase\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .code(1);
+}
+
+// --- Empty project ---
+
+#[test]
+fn test_lint_empty_project() {
+    let dir = setup_project(&[("main.rs", "fn main() {}\n")]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+// --- Multiple files ---
+
+#[test]
+fn test_lint_multiple_files() {
+    let dir = setup_project(&[
+        ("src/a.rs", "// TODO: valid in file a\n"),
+        ("src/b.rs", "// TODO: valid in file b\n"),
+    ]);
+
+    todox()
+        .args(["lint", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}


### PR DESCRIPTION
## Summary

- Add `todox lint` subcommand that validates TODO comment formatting against configurable rules
- 6 lint rules: `no_bare_tags`, `uppercase_tag`, `require_colon`, `max_message_length`, `require_author`, `require_issue_ref`
- Supports all output formats: text, JSON, GitHub Actions, SARIF, Markdown
- CI-ready: exits with code 1 on violations, code 0 on pass

Closes #23

## Test Plan

- [x] 14 unit tests in `src/lint.rs` covering each rule and config resolution
- [x] 29 integration tests in `tests/integration_lint.rs` covering pass/fail cases, all output formats, config file integration, exit codes
- [x] `cargo test` — all tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no warnings
- [x] Schema regenerated and validated