### PR TITLE
fix(scanner): add word boundary after tag in regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo build --release
 
       - name: TODO gate
-        run: cargo run --release -- check --max 105
+        run: cargo run --release -- check --max 84
 
       - name: TODO diff (PR only)
         if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ Tags: `TODO`, `FIXME`, `HACK`, `XXX`, `BUG`, `NOTE` (case-insensitive)
 // TODO(alice, 2025-Q2): refactor auth   ← author + deadline (quarter)
 ```
 
+### Supported comment syntax
+
+The scanner uses line-based heuristic comment detection, not a language parser. The following comment prefixes are recognized:
+
+| Prefix | Languages |
+|--------|-----------|
+| `//`   | Rust, C/C++, Java, Go, JavaScript, TypeScript, Swift, Kotlin, C# |
+| `#`    | Python, Ruby, Shell, YAML, TOML, Perl, R |
+| `/* `  | C/C++, Java, JavaScript, CSS (block comment start) |
+| ` * `  | Block comment continuation lines |
+| `--`   | SQL, Haskell, Lua, Ada |
+| `<!--` | HTML, XML, Markdown |
+| `;`    | Lisp, Clojure, Assembly, INI |
+| `(*`   | OCaml, Pascal, F# |
+| `{-`   | Haskell (block) |
+| `%`    | LaTeX, Erlang, MATLAB |
+
+> **Note:** Detection is line-based. Multi-line constructs (Python docstrings, heredocs) are not supported. Tags must appear as standalone words — `todox` and `TODOS` will not match `TODO`.
+
 ## Installation
 
 ```bash

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,7 +105,7 @@ impl Config {
     /// Build regex pattern from configured tags
     pub fn tags_pattern(&self) -> String {
         let tags = self.tags.join("|");
-        format!(r"(?i)\b({tags})(?:\(([^)]+)\))?:?\s*(!{{1,2}})?\s*(.*)$")
+        format!(r"(?i)\b({tags})\b(?:\(([^)]+)\))?:?\s*(!{{1,2}})?\s*(.*)$")
     }
 
     /// Load config from .todox.toml, searching up from the given directory

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -794,4 +794,84 @@ line four
         assert!(items[0].author.is_none());
         assert!(items[0].deadline.is_none());
     }
+
+    // --- Word boundary after tag: false-positive rejection ---
+
+    #[test]
+    fn test_no_match_todox_in_comment() {
+        let pattern = default_pattern();
+        let content = "// todox report generates HTML\n";
+        let items = scan_content(content, "test.rs", &pattern);
+        assert!(
+            items.is_empty(),
+            "should not match TODO as prefix of 'todox'"
+        );
+    }
+
+    #[test]
+    fn test_no_match_todos_in_comment() {
+        let pattern = default_pattern();
+        let content = "// TODOS remaining in the backlog\n";
+        let items = scan_content(content, "test.rs", &pattern);
+        assert!(
+            items.is_empty(),
+            "should not match TODO as prefix of 'TODOS'"
+        );
+    }
+
+    #[test]
+    fn test_no_match_noted_in_comment() {
+        let pattern = default_pattern();
+        let content = "# NOTEd this for future reference\n";
+        let items = scan_content(content, "test.rs", &pattern);
+        assert!(
+            items.is_empty(),
+            "should not match NOTE as prefix of 'NOTEd'"
+        );
+    }
+
+    #[test]
+    fn test_no_match_fixme_suffix_in_comment() {
+        let pattern = default_pattern();
+        let content = "// FIXMEd the issue yesterday\n";
+        let items = scan_content(content, "test.rs", &pattern);
+        assert!(
+            items.is_empty(),
+            "should not match FIXME as prefix of 'FIXMEd'"
+        );
+    }
+
+    // --- Word boundary after tag: legitimate patterns still match ---
+
+    #[test]
+    fn test_still_matches_todo_colon() {
+        let pattern = default_pattern();
+        let content = "// TODO: fix this\n";
+        let items = scan_content(content, "test.rs", &pattern);
+        assert_eq!(items.len(), 1, "TODO: should still match");
+    }
+
+    #[test]
+    fn test_still_matches_todo_paren() {
+        let pattern = default_pattern();
+        let content = "// TODO(alice): fix this\n";
+        let items = scan_content(content, "test.rs", &pattern);
+        assert_eq!(items.len(), 1, "TODO(author) should still match");
+    }
+
+    #[test]
+    fn test_still_matches_todo_space() {
+        let pattern = default_pattern();
+        let content = "// TODO fix this\n";
+        let items = scan_content(content, "test.rs", &pattern);
+        assert_eq!(items.len(), 1, "TODO followed by space should still match");
+    }
+
+    #[test]
+    fn test_still_matches_todo_bang() {
+        let pattern = default_pattern();
+        let content = "// TODO! fix this\n";
+        let items = scan_content(content, "test.rs", &pattern);
+        assert_eq!(items.len(), 1, "TODO! should still match");
+    }
 }


### PR DESCRIPTION
## Summary

- Add trailing `\b` to `tags_pattern()` regex to prevent false positives when tags appear as prefixes of longer words (e.g., `todox`, `TODOS`, `NOTEd`)
- Add 8 unit tests: 4 for false-positive rejection, 4 for regression on legitimate patterns
- Lower CI TODO gate threshold from 105 to 84 (19 false positives eliminated)
- Document supported comment syntax in README

Closes #72

## Test Plan

- [x] Unit tests added (8 new tests for word boundary behavior)
- [x] All 374 tests pass (`cargo test`)
- [x] `cargo fmt --check` passes
- [x] `cargo check` passes
- [x] Manual verification: `todox list` shows 84 items (down from 101)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed false-positive tag matches by adding a trailing word boundary (`\b`) to the regex pattern in `tags_pattern()`. This prevents partial matches where tags appear as prefixes of longer words (e.g., `todox`, `TODOS`, `NOTEd`).

**Key changes:**
- Modified regex in `src/config.rs:108` from `\b({tags})(?:` to `\b({tags})\b(?:` to enforce word boundaries on both sides
- Added 8 unit tests covering false-positive rejection (`todox`, `TODOS`, `NOTEd`, `FIXMEd`) and regression testing for legitimate patterns (`TODO:`, `TODO(author)`, `TODO `, `TODO!`)
- Updated CI TODO gate threshold from 105 to 84 (eliminated 21 false positives)
- Documented supported comment syntax and word boundary behavior in README

The regex change is minimal, well-tested, and directly addresses the issue described in #72. All legitimate TODO patterns continue to match correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-character addition to a regex pattern with comprehensive test coverage. The 8 new unit tests validate both the fix (4 false-positive rejection tests) and backwards compatibility (4 regression tests). The CI threshold update accurately reflects the reduction in false positives. All changes are well-documented and aligned with the stated goal.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/config.rs | Added trailing `\b` word boundary to regex pattern to prevent false positives |
| src/scanner.rs | Added 8 comprehensive unit tests for word boundary behavior (4 false-positive rejection, 4 regression) |
| .github/workflows/ci.yml | Lowered TODO gate threshold from 105 to 84, reflecting elimination of 21 false positives |
| README.md | Added comprehensive documentation for supported comment syntax and word boundary behavior |

</details>



<sub>Last reviewed commit: 3b964ef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->