### PR TITLE
fix(scanner): add quote-awareness to is_in_comment (#74)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo build --release
 
       - name: TODO gate
-        run: cargo run --release -- check --max 105
+        run: cargo run --release -- check --max 80
 
       - name: TODO diff (PR only)
         if: github.event_name == 'pull_request'

--- a/.todox.toml
+++ b/.todox.toml
@@ -15,7 +15,7 @@ exclude_patterns = [
 ]
 
 [check]
-max = 100
+max = 80
 
 [blame]
 stale_threshold = "365d"


### PR DESCRIPTION
## Summary

- Add `prefix_outside_quotes()` quote-parity heuristic to `is_in_comment()` so comment prefixes inside string literals are rejected as false positives
- Add 8 new tests (5 `is_in_comment` unit tests + 3 `scan_content` integration tests)
- Lower CI gate threshold from 105 → 80 to reflect the reduced false-positive count (76 actual TODOs)

Closes #74

## Test Plan

- [x] Unit tests: string literals with `//`, `#`, `/*` prefixes → `is_in_comment` returns false
- [x] Unit test: real inline comment after code → still matches
- [x] Unit test: `"//"; // TODO` mixed case → matches the real comment
- [x] Integration tests: `scan_content` with string literal lines → 0 matches
- [x] Integration test: `scan_content` with quoted prefix then real comment → 1 match
- [x] Full test suite: 402 tests pass, 0 failures
- [x] `cargo run -- check --max 80` → PASS
- [x] `cargo fmt --check` → clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds quote-awareness to the comment detection heuristic, preventing false-positive TODO matches inside string literals. The implementation uses a simple quote-parity check (even number of `"` before a comment prefix means it's outside strings) which handles the most common cases effectively.

**Key changes:**
- Added `prefix_outside_quotes()` helper that counts double quotes before a position
- Modified `is_in_comment()` to iterate through all occurrences of comment prefixes and check each one with the quote heuristic
- Added 8 new tests covering string literals with various comment prefixes
- Reduced CI gate threshold from 105→80 to reflect the 25 fewer false positives detected

**Limitations of the heuristic:**
The quote-parity approach is intentionally simple and doesn't handle all edge cases (single quotes, escaped quotes, template literals, raw strings, multi-line strings). This is acceptable for a heuristic-based tool designed to reduce false positives rather than eliminate them entirely.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor heuristic limitations acknowledged
- Well-tested implementation with 8 new tests and full test suite passing (402 tests). The quote-parity heuristic is simple but effective for common cases. Score of 4 (not 5) reflects inherent limitations of the heuristic approach (doesn't handle single quotes, escaped quotes, etc.), though these are acceptable trade-offs for this type of tool.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/scanner.rs | Adds quote-awareness heuristic to `is_in_comment()` to filter TODOs in string literals; includes 8 new tests validating the behavior |
| .github/workflows/ci.yml | Reduces TODO gate threshold from 105 to 80 to match actual TODO count after false-positive reduction |
| .todox.toml | Updates max TODO threshold from 100 to 80 to reflect reduced false-positive count |

</details>



<sub>Last reviewed commit: 98370a4</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=222a0453-b647-4f29-b563-3e55a457947c))

<!-- /greptile_comment -->