### PR TITLE
docs(readme): fix formatting of features list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ Track TODO/FIXME/HACK comments in your codebase with git-aware diff and CI gate.
 ## Features
 
 1. **Discover**
-  - [Scan & List TODOs](#scan--list-todos) · [Search TODOs](#search-todos) · [Inline Code Context](#inline-code-context)
+     - [Scan & List TODOs](#scan--list-todos) · [Search TODOs](#search-todos) · [Inline Code Context](#inline-code-context)
 2. **Analyze**
-  - [Diff Against Git Refs](#diff-against-git-refs) · [Dashboard & Statistics](#dashboard--statistics) · [Git Blame Integration](#git-blame-integration) · [Discover TODO Relationships](#discover-todo-relationships)
+     - [Diff Against Git Refs](#diff-against-git-refs) · [Dashboard & Statistics](#dashboard--statistics) · [Git Blame Integration](#git-blame-integration) · [Discover TODO Relationships](#discover-todo-relationships)
 3. **Enforce**
-  - [Lint TODO Format](#lint-todo-format) · [Clean Stale & Duplicate TODOs](#clean-stale--duplicate-todos) · [CI Quality Gate](#ci-quality-gate)
+     - [Lint TODO Format](#lint-todo-format) · [Clean Stale & Duplicate TODOs](#clean-stale--duplicate-todos) · [CI Quality Gate](#ci-quality-gate)
 4. **Scale**
-  - [Workspace-Aware Scanning](#workspace-aware-scanning) · [Per-Package CI Gate](#per-package-ci-gate) · [Single Package Scope](#single-package-scope)
+     - [Workspace-Aware Scanning](#workspace-aware-scanning) · [Per-Package CI Gate](#per-package-ci-gate) · [Single Package Scope](#single-package-scope)
 5. **Report & Integrate**
-  - [HTML Report Generation](#html-report-generation) · [CI Output Formats](#ci-output-formats) · [Claude Code Task Export](#claude-code-task-export)
+     - [HTML Report Generation](#html-report-generation) · [CI Output Formats](#ci-output-formats) · [Claude Code Task Export](#claude-code-task-export)
 6. **Productivity**
-  - [Real-time File Watching](#real-time-file-watching) · [Interactive Setup](#interactive-setup) · [Shell Completions](#shell-completions)
+     - [Real-time File Watching](#real-time-file-watching) · [Interactive Setup](#interactive-setup) · [Shell Completions](#shell-completions)
 
 ### Scan & List TODOs
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed markdown formatting in the Features section by correcting the indentation of nested bullet points from 2 spaces to 5 spaces, ensuring proper rendering of sub-items under numbered list items.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge - it only fixes markdown formatting
- This is a documentation-only change that corrects indentation in a markdown file with no risk of breaking functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Fixed indentation of nested bullet points in Features section from 2 to 5 spaces for proper markdown rendering |

</details>



<sub>Last reviewed commit: 20f51ca</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->