### PR TITLE
chore(deps): remove unused thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "time",
  "toml",
  "toml_edit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1"
 dialoguer = "0.11"
 clap_complete = "4"
 toml_edit = "0.22"
-thiserror = "2"
 time = { version = "0.3", features = ["local-offset"] }
 notify = "7"
 notify-debouncer-mini = "0.5"


### PR DESCRIPTION
## Summary

Remove the unused `thiserror` dependency from `Cargo.toml`. The crate was declared but never imported or used anywhere in the codebase. This reduces compile time and shrinks the dependency tree.

Closes #94

## Test Plan

- [x] `cargo build` — compiles without errors
- [x] `cargo test` — all tests pass
- [x] `cargo fmt --check` — no formatting issues
- [x] `cargo check` — no type errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed the unused `thiserror` dependency from the project. The codebase uses `anyhow` for error handling throughout (confirmed across all source files), and `thiserror` was never imported or used. This cleanup reduces compile time and simplifies the dependency tree without affecting functionality.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple dependency removal with no code changes. Verified `thiserror` is completely unused in the codebase (no imports, no usage). The PR author has already confirmed successful build, tests, and checks.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Removed unused `thiserror` dependency declaration |
| Cargo.lock | Removed `thiserror` from dependency tree (auto-generated) |

</details>



<sub>Last reviewed commit: 6552a9d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->