### PR TITLE
refactor(clippy): resolve all warnings for CI compliance

### DIFF
--- a/src/blame.rs
+++ b/src/blame.rs
@@ -222,7 +222,7 @@ mod tests {
         // 30 days ago
         let thirty_days_ago = now - (30 * 86400);
         let age = compute_age_days(thirty_days_ago);
-        assert!(age >= 29 && age <= 31);
+        assert!((29..=31).contains(&age));
     }
 
     #[test]

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -59,10 +59,13 @@ fn item_to_result(item: &TodoItem) -> serde_json::Value {
         }]
     });
     if let Some(ref deadline) = item.deadline {
-        result.as_object_mut().unwrap().insert(
-            "properties".to_string(),
-            serde_json::json!({ "deadline": deadline.to_string() }),
-        );
+        result
+            .as_object_mut()
+            .expect("SARIF result should be a JSON object")
+            .insert(
+                "properties".to_string(),
+                serde_json::json!({ "deadline": deadline.to_string() }),
+            );
     }
     result
 }
@@ -95,10 +98,12 @@ pub fn format_diff(result: &DiffResult) -> String {
                 DiffStatus::Added => "added",
                 DiffStatus::Removed => "removed",
             };
-            r.as_object_mut().unwrap().insert(
-                "properties".to_string(),
-                serde_json::json!({ "diffStatus": status }),
-            );
+            r.as_object_mut()
+                .expect("SARIF result should be a JSON object")
+                .insert(
+                    "properties".to_string(),
+                    serde_json::json!({ "diffStatus": status }),
+                );
             r
         })
         .collect();
@@ -116,19 +121,21 @@ pub fn format_blame(result: &BlameResult) -> String {
         .iter()
         .map(|entry| {
             let mut r = item_to_result(&entry.item);
-            r.as_object_mut().unwrap().insert(
-                "properties".to_string(),
-                serde_json::json!({
-                    "blame": {
-                        "author": entry.blame.author,
-                        "email": entry.blame.email,
-                        "date": entry.blame.date,
-                        "ageDays": entry.blame.age_days,
-                        "commit": entry.blame.commit,
-                        "stale": entry.stale,
-                    }
-                }),
-            );
+            r.as_object_mut()
+                .expect("SARIF result should be a JSON object")
+                .insert(
+                    "properties".to_string(),
+                    serde_json::json!({
+                        "blame": {
+                            "author": entry.blame.author,
+                            "email": entry.blame.email,
+                            "date": entry.blame.date,
+                            "ageDays": entry.blame.age_days,
+                            "commit": entry.blame.commit,
+                            "stale": entry.stale,
+                        }
+                    }),
+                );
             r
         })
         .collect();
@@ -163,14 +170,16 @@ pub fn format_lint(result: &LintResult) -> String {
                 }]
             });
             if let Some(ref suggestion) = v.suggestion {
-                r.as_object_mut().unwrap().insert(
-                    "fixes".to_string(),
-                    serde_json::json!([{
-                        "description": {
-                            "text": suggestion
-                        }
-                    }]),
-                );
+                r.as_object_mut()
+                    .expect("SARIF result should be a JSON object")
+                    .insert(
+                        "fixes".to_string(),
+                        serde_json::json!([{
+                            "description": {
+                                "text": suggestion
+                            }
+                        }]),
+                    );
             }
             r
         })

--- a/src/relate.rs
+++ b/src/relate.rs
@@ -659,7 +659,7 @@ mod tests {
 
     #[test]
     fn generate_theme_extracts_top_keywords() {
-        let items = vec![
+        let items = [
             make_item(
                 "src/auth.rs",
                 10,
@@ -677,7 +677,7 @@ mod tests {
 
     #[test]
     fn compute_suggested_order_by_priority_then_severity() {
-        let items = vec![
+        let items = [
             make_item("src/a.rs", 10, Tag::Note, "low prio note"),
             {
                 let mut item = make_item("src/b.rs", 20, Tag::Bug, "urgent bug");

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -241,7 +241,7 @@ pub fn scan_directory(root: &Path, config: &Config) -> Result<ScanResult> {
 
             let found = scan_content(&content, &relative_path, &pattern);
             if !found.is_empty() {
-                items.lock().unwrap().extend(found);
+                items.lock().expect("scan thread panicked").extend(found);
             }
             files_scanned.fetch_add(1, Ordering::Relaxed);
 

--- a/tests/integration_blame.rs
+++ b/tests/integration_blame.rs
@@ -5,7 +5,7 @@ use std::process;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_git_repo(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_cache.rs
+++ b/tests/integration_cache.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_check.rs
+++ b/tests/integration_check.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_clean.rs
+++ b/tests/integration_clean.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_completions.rs
+++ b/tests/integration_completions.rs
@@ -2,7 +2,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 #[test]

--- a/tests/integration_context.rs
+++ b/tests/integration_context.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_diff.rs
+++ b/tests/integration_diff.rs
@@ -5,7 +5,7 @@ use std::process;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_git_repo(initial_files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_init.rs
+++ b/tests/integration_init.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 #[test]

--- a/tests/integration_lint.rs
+++ b/tests/integration_lint.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_list.rs
+++ b/tests/integration_list.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_relate.rs
+++ b/tests/integration_relate.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_report.rs
+++ b/tests/integration_report.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_search.rs
+++ b/tests/integration_search.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_stats.rs
+++ b/tests/integration_stats.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_tasks.rs
+++ b/tests/integration_tasks.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {

--- a/tests/integration_workspace.rs
+++ b/tests/integration_workspace.rs
@@ -4,7 +4,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn todox() -> Command {
-    Command::cargo_bin("todox").unwrap()
+    assert_cmd::cargo_bin_cmd!("todox")
 }
 
 fn setup_project(files: &[(&str, &str)]) -> TempDir {


### PR DESCRIPTION
## Summary

- Fix all `cargo clippy --all-targets` warnings across production and test code
- Replace deprecated `assert_cmd` APIs (`Command::cargo_bin`, `cargo::cargo_bin`) with recommended macros (`cargo_bin_cmd!`, `cargo_bin!`)
- Replace `.unwrap()` with descriptive `.expect()` messages in scanner and SARIF output
- Use idiomatic Rust patterns (`contains()`, array literals, `map_while`)

Closes #95

## Test Plan

- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test` — all 284 unit tests + all integration tests pass
- [x] `cargo fmt --check` — no formatting issues

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Resolved all clippy warnings across production and test code to achieve CI compliance. Major changes include:

- **Test infrastructure**: Migrated all 17 integration test files from deprecated `assert_cmd` APIs (`Command::cargo_bin()`, `cargo::cargo_bin()`) to recommended macros (`cargo_bin_cmd!()`, `cargo_bin!()`)
- **Error handling**: Replaced `.unwrap()` calls with descriptive `.expect()` messages in `scanner.rs` (mutex lock) and `sarif.rs` (JSON object mutations) for better panic diagnostics
- **Idiomatic patterns**: Applied Rust best practices including `contains()` for range checks, array literals instead of `vec![]` for test fixtures, and `map_while()` for iterator operations

All 284 unit tests and integration tests pass, zero clippy warnings remain.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - all changes are mechanical refactorings to address clippy warnings
- Perfect score justified by: (1) all changes are mechanical clippy fixes with no logic alterations, (2) comprehensive test coverage with 284 passing tests validates correctness, (3) changes follow Rust best practices and improve code quality, (4) migration from deprecated APIs ensures future compatibility
- No files require special attention - all changes are straightforward refactorings

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/blame.rs | Replaced `&&` condition with idiomatic `contains()` check on range in test |
| src/output/sarif.rs | Replaced `.unwrap()` with descriptive `.expect()` messages for JSON object mutations |
| src/relate.rs | Changed `vec![]` to array literals `[]` in test fixtures for better performance |
| src/scanner.rs | Replaced `.unwrap()` with `.expect()` and descriptive panic message for mutex lock |
| tests/integration_watch.rs | Migrated from `Command::cargo_bin()` and `cargo::cargo_bin()` to macros; replaced loop with `map_while()` |

</details>



<sub>Last reviewed commit: b31e0ce</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->