### PR TITLE
refactor(model): deduplicate priority sort logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -375,17 +375,8 @@ fn cmd_search(
                 .then(a.line.cmp(&b.line))
         }),
         SortBy::Priority => result.items.sort_by(|a, b| {
-            let pa = match a.priority {
-                model::Priority::Urgent => 2,
-                model::Priority::High => 1,
-                model::Priority::Normal => 0,
-            };
-            let pb = match b.priority {
-                model::Priority::Urgent => 2,
-                model::Priority::High => 1,
-                model::Priority::Normal => 0,
-            };
-            pb.cmp(&pa)
+            b.priority
+                .cmp(&a.priority)
                 .then(a.file.cmp(&b.file))
                 .then(a.line.cmp(&b.line))
         }),
@@ -467,17 +458,8 @@ fn cmd_list(
                 .then(a.line.cmp(&b.line))
         }),
         SortBy::Priority => result.items.sort_by(|a, b| {
-            let pa = match a.priority {
-                model::Priority::Urgent => 2,
-                model::Priority::High => 1,
-                model::Priority::Normal => 0,
-            };
-            let pb = match b.priority {
-                model::Priority::Urgent => 2,
-                model::Priority::High => 1,
-                model::Priority::Normal => 0,
-            };
-            pb.cmp(&pa)
+            b.priority
+                .cmp(&a.priority)
                 .then(a.file.cmp(&b.file))
                 .then(a.line.cmp(&b.line))
         }),

--- a/src/model.rs
+++ b/src/model.rs
@@ -61,12 +61,34 @@ impl fmt::Display for Tag {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Priority {
     Normal,
     High,
     Urgent,
+}
+
+impl Priority {
+    pub fn numeric_order(&self) -> u8 {
+        match self {
+            Priority::Urgent => 2,
+            Priority::High => 1,
+            Priority::Normal => 0,
+        }
+    }
+}
+
+impl PartialOrd for Priority {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Priority {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.numeric_order().cmp(&other.numeric_order())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -439,6 +461,37 @@ pub struct RelateResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn priority_numeric_order_values() {
+        assert_eq!(Priority::Normal.numeric_order(), 0);
+        assert_eq!(Priority::High.numeric_order(), 1);
+        assert_eq!(Priority::Urgent.numeric_order(), 2);
+    }
+
+    #[test]
+    fn priority_ord_urgent_gt_high_gt_normal() {
+        assert!(Priority::Urgent > Priority::High);
+        assert!(Priority::High > Priority::Normal);
+        assert!(Priority::Urgent > Priority::Normal);
+    }
+
+    #[test]
+    fn priority_ord_equality() {
+        assert_eq!(Priority::Normal, Priority::Normal);
+        assert_eq!(Priority::High, Priority::High);
+        assert_eq!(Priority::Urgent, Priority::Urgent);
+    }
+
+    #[test]
+    fn priority_ord_sorting() {
+        let mut priorities = vec![Priority::Normal, Priority::Urgent, Priority::High];
+        priorities.sort();
+        assert_eq!(
+            priorities,
+            vec![Priority::Normal, Priority::High, Priority::Urgent]
+        );
+    }
 
     #[test]
     fn workspace_kind_display() {

--- a/src/relate.rs
+++ b/src/relate.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::model::{Cluster, Priority, RelateResult, Relationship, ScanResult, TodoItem};
+use crate::model::{Cluster, RelateResult, Relationship, ScanResult, TodoItem};
 
 const STOPWORDS: &[&str] = &[
     "a", "an", "the", "is", "it", "in", "to", "of", "for", "on", "and", "or", "but", "not", "with",
@@ -280,15 +280,8 @@ pub fn generate_theme(items: &[&TodoItem]) -> String {
 
 pub fn compute_suggested_order(items: &mut [&TodoItem]) {
     items.sort_by(|a, b| {
-        let priority_ord = |p: &Priority| -> u8 {
-            match p {
-                Priority::Urgent => 0,
-                Priority::High => 1,
-                Priority::Normal => 2,
-            }
-        };
-        priority_ord(&a.priority)
-            .cmp(&priority_ord(&b.priority))
+        b.priority
+            .cmp(&a.priority)
             .then(b.tag.severity().cmp(&a.tag.severity()))
             .then(a.file.cmp(&b.file))
             .then(a.line.cmp(&b.line))

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -131,17 +131,8 @@ pub fn build_tasks(
 /// Sort items by priority (Urgent > High > Normal), then tag severity, then file/line.
 pub fn sort_by_priority(items: &mut [TodoItem]) {
     items.sort_by(|a, b| {
-        let pa = match a.priority {
-            Priority::Urgent => 2,
-            Priority::High => 1,
-            Priority::Normal => 0,
-        };
-        let pb = match b.priority {
-            Priority::Urgent => 2,
-            Priority::High => 1,
-            Priority::Normal => 0,
-        };
-        pb.cmp(&pa)
+        b.priority
+            .cmp(&a.priority)
             .then(b.tag.severity().cmp(&a.tag.severity()))
             .then(a.file.cmp(&b.file))
             .then(a.line.cmp(&b.line))


### PR DESCRIPTION
## Summary

- Add `Ord`/`PartialOrd` impl and `numeric_order()` method to `Priority` enum in `model.rs`
- Replace 4 duplicated priority-to-numeric match blocks with `b.priority.cmp(&a.priority)`
- Simplify sort logic in `cmd_list()`, `cmd_search()`, `sort_by_priority()`, and `compute_suggested_order()`

Closes #91

## Test Plan

- [x] Unit tests for `Priority::numeric_order()` values (Normal=0, High=1, Urgent=2)
- [x] Unit tests for `Ord` impl (Urgent > High > Normal, equality, sorting)
- [x] Existing `sort_by_priority` tests in `tasks.rs` pass without changes
- [x] Existing `compute_suggested_order` tests in `relate.rs` pass without changes
- [x] Full `cargo test` passes (288 unit tests + all integration tests)
- [x] `cargo fmt --check` passes
- [x] `cargo check` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored priority sorting logic by implementing `Ord` and `PartialOrd` traits on the `Priority` enum, eliminating 4 instances of duplicated priority-to-numeric conversion code across `main.rs`, `tasks.rs`, and `relate.rs`.

**Key Changes:**
- Added `Hash` derive to `Priority` enum for completeness
- Implemented `numeric_order()` method and `Ord`/`PartialOrd` traits for `Priority`
- Replaced all manual priority comparisons with direct `b.priority.cmp(&a.priority)` calls
- Added comprehensive unit tests for the new trait implementations
- Removed unused `Priority` import from `relate.rs`

The refactoring maintains the same sorting behavior (Urgent > High > Normal descending order) while significantly improving code maintainability and reducing duplication.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues identified
- Clean refactoring with comprehensive tests, maintains existing behavior, eliminates code duplication, and follows Rust best practices
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/model.rs | Added `Ord`/`PartialOrd` traits and `numeric_order()` method to `Priority` enum with comprehensive unit tests |
| src/main.rs | Simplified priority sorting in `cmd_list()` and `cmd_search()` by using `Priority::cmp()` instead of duplicated match blocks |
| src/tasks.rs | Replaced duplicated priority-to-numeric conversion in `sort_by_priority()` with direct priority comparison |
| src/relate.rs | Simplified `compute_suggested_order()` by removing local closure and using built-in priority comparison, removed unused import |

</details>



<sub>Last reviewed commit: 5b0c241</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->