### PR TITLE
refactor(cmd): extract common filter functions (#92)

### DIFF
--- a/src/cmd/filter.rs
+++ b/src/cmd/filter.rs
@@ -1,0 +1,202 @@
+use anyhow::{Context, Result};
+
+use crate::cli::PriorityFilter;
+use crate::model::{self, Tag, TodoItem};
+
+pub struct FilterOptions {
+    pub tags: Vec<String>,
+    pub author: Option<String>,
+    pub path: Option<String>,
+    pub priority: Vec<PriorityFilter>,
+}
+
+pub fn apply_filters(items: &mut Vec<TodoItem>, filters: &FilterOptions) -> Result<()> {
+    // Apply tag filter
+    if !filters.tags.is_empty() {
+        let filter_tags: Vec<Tag> = filters
+            .tags
+            .iter()
+            .filter_map(|s| s.parse::<Tag>().ok())
+            .collect();
+        items.retain(|item| filter_tags.contains(&item.tag));
+    }
+
+    // Apply priority filter
+    if !filters.priority.is_empty() {
+        let priorities: Vec<model::Priority> =
+            filters.priority.iter().map(|p| p.to_priority()).collect();
+        items.retain(|item| priorities.contains(&item.priority));
+    }
+
+    // Apply author filter
+    if let Some(ref author) = filters.author {
+        items.retain(|item| item.author.as_deref() == Some(author.as_str()));
+    }
+
+    // Apply path filter
+    if let Some(ref pattern) = filters.path {
+        let glob = globset::Glob::new(pattern)
+            .context("invalid glob pattern")?
+            .compile_matcher();
+        items.retain(|item| glob.is_match(&item.file));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Priority, Tag, TodoItem};
+
+    fn make_item(file: &str, tag: Tag, priority: Priority, author: Option<&str>) -> TodoItem {
+        TodoItem {
+            file: file.to_string(),
+            line: 1,
+            tag,
+            message: "test".to_string(),
+            author: author.map(|a| a.to_string()),
+            issue_ref: None,
+            priority,
+            deadline: None,
+        }
+    }
+
+    #[test]
+    fn filter_by_tag() {
+        let mut items = vec![
+            make_item("a.rs", Tag::Todo, Priority::Normal, None),
+            make_item("b.rs", Tag::Fixme, Priority::Normal, None),
+            make_item("c.rs", Tag::Hack, Priority::Normal, None),
+        ];
+        let filters = FilterOptions {
+            tags: vec!["TODO".to_string()],
+            author: None,
+            path: None,
+            priority: vec![],
+        };
+        apply_filters(&mut items, &filters).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].tag, Tag::Todo);
+    }
+
+    #[test]
+    fn filter_by_multiple_tags() {
+        let mut items = vec![
+            make_item("a.rs", Tag::Todo, Priority::Normal, None),
+            make_item("b.rs", Tag::Fixme, Priority::Normal, None),
+            make_item("c.rs", Tag::Hack, Priority::Normal, None),
+        ];
+        let filters = FilterOptions {
+            tags: vec!["TODO".to_string(), "HACK".to_string()],
+            author: None,
+            path: None,
+            priority: vec![],
+        };
+        apply_filters(&mut items, &filters).unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].tag, Tag::Todo);
+        assert_eq!(items[1].tag, Tag::Hack);
+    }
+
+    #[test]
+    fn filter_by_priority() {
+        let mut items = vec![
+            make_item("a.rs", Tag::Todo, Priority::Normal, None),
+            make_item("b.rs", Tag::Todo, Priority::High, None),
+            make_item("c.rs", Tag::Todo, Priority::Urgent, None),
+        ];
+        let filters = FilterOptions {
+            tags: vec![],
+            author: None,
+            path: None,
+            priority: vec![PriorityFilter::High],
+        };
+        apply_filters(&mut items, &filters).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].priority, Priority::High);
+    }
+
+    #[test]
+    fn filter_by_author() {
+        let mut items = vec![
+            make_item("a.rs", Tag::Todo, Priority::Normal, Some("alice")),
+            make_item("b.rs", Tag::Todo, Priority::Normal, Some("bob")),
+            make_item("c.rs", Tag::Todo, Priority::Normal, None),
+        ];
+        let filters = FilterOptions {
+            tags: vec![],
+            author: Some("alice".to_string()),
+            path: None,
+            priority: vec![],
+        };
+        apply_filters(&mut items, &filters).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].author.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn filter_by_path() {
+        let mut items = vec![
+            make_item("src/main.rs", Tag::Todo, Priority::Normal, None),
+            make_item("src/lib.rs", Tag::Todo, Priority::Normal, None),
+            make_item("tests/test.rs", Tag::Todo, Priority::Normal, None),
+        ];
+        let filters = FilterOptions {
+            tags: vec![],
+            author: None,
+            path: Some("src/*.rs".to_string()),
+            priority: vec![],
+        };
+        apply_filters(&mut items, &filters).unwrap();
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|i| i.file.starts_with("src/")));
+    }
+
+    #[test]
+    fn filter_combined() {
+        let mut items = vec![
+            make_item("src/main.rs", Tag::Todo, Priority::High, Some("alice")),
+            make_item("src/lib.rs", Tag::Fixme, Priority::Normal, Some("alice")),
+            make_item("tests/test.rs", Tag::Todo, Priority::High, Some("bob")),
+            make_item("src/util.rs", Tag::Todo, Priority::Normal, Some("alice")),
+        ];
+        let filters = FilterOptions {
+            tags: vec!["TODO".to_string()],
+            author: Some("alice".to_string()),
+            path: Some("src/**".to_string()),
+            priority: vec![PriorityFilter::High],
+        };
+        apply_filters(&mut items, &filters).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].file, "src/main.rs");
+    }
+
+    #[test]
+    fn empty_filters_retain_all() {
+        let mut items = vec![
+            make_item("a.rs", Tag::Todo, Priority::Normal, None),
+            make_item("b.rs", Tag::Fixme, Priority::High, Some("alice")),
+        ];
+        let filters = FilterOptions {
+            tags: vec![],
+            author: None,
+            path: None,
+            priority: vec![],
+        };
+        apply_filters(&mut items, &filters).unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn invalid_glob_returns_error() {
+        let mut items = vec![make_item("a.rs", Tag::Todo, Priority::Normal, None)];
+        let filters = FilterOptions {
+            tags: vec![],
+            author: None,
+            path: Some("[invalid".to_string()),
+            priority: vec![],
+        };
+        assert!(apply_filters(&mut items, &filters).is_err());
+    }
+}

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,16 +1,15 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use crate::cli::{Format, GroupBy, PriorityFilter, SortBy};
 use crate::config::Config;
 use crate::context::collect_context_map;
-use crate::model;
-use crate::model::Tag;
 use crate::output::print_list;
 
 use super::do_scan;
+use super::filter::{apply_filters, FilterOptions};
 
 pub struct ListOptions {
     pub tag: Vec<String>,
@@ -32,39 +31,15 @@ pub fn cmd_list(
 ) -> Result<()> {
     let mut result = do_scan(root, config, no_cache)?;
 
-    // Apply tag filter
-    if !opts.tag.is_empty() {
-        let filter_tags: Vec<Tag> = opts
-            .tag
-            .iter()
-            .filter_map(|s| s.parse::<Tag>().ok())
-            .collect();
-        result.items.retain(|item| filter_tags.contains(&item.tag));
-    }
-
-    // Apply priority filter
-    if !opts.priority.is_empty() {
-        let priorities: Vec<model::Priority> =
-            opts.priority.iter().map(|p| p.to_priority()).collect();
-        result
-            .items
-            .retain(|item| priorities.contains(&item.priority));
-    }
-
-    // Apply author filter
-    if let Some(ref author) = opts.author {
-        result
-            .items
-            .retain(|item| item.author.as_deref() == Some(author.as_str()));
-    }
-
-    // Apply path filter
-    if let Some(ref pattern) = opts.path {
-        let glob = globset::Glob::new(pattern)
-            .context("invalid glob pattern")?
-            .compile_matcher();
-        result.items.retain(|item| glob.is_match(&item.file));
-    }
+    apply_filters(
+        &mut result.items,
+        &FilterOptions {
+            tags: opts.tag,
+            author: opts.author,
+            path: opts.path,
+            priority: opts.priority,
+        },
+    )?;
 
     // Apply sort
     match opts.sort {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3,6 +3,7 @@ mod check;
 mod clean;
 mod context;
 mod diff;
+mod filter;
 mod lint;
 mod list;
 mod relate;


### PR DESCRIPTION
## Summary

- Extract duplicated tag/author/path/priority filtering logic from `cmd/list.rs`, `cmd/search.rs`, and `cmd/tasks.rs` into a shared `cmd/filter.rs` module
- New `FilterOptions` struct and `apply_filters()` function consolidate ~85 lines of repeated filter-and-retain code into a single reusable function
- 8 unit tests cover each filter type individually, combined filters, empty filters, and invalid glob error handling

Closes #92

## Test Plan

- [x] Unit tests added for `apply_filters()` (tag, multiple tags, priority, author, path, combined, empty, invalid glob)
- [x] All 296 existing unit tests pass
- [x] All integration tests pass (list, search, tasks, and all other commands)
- [x] `cargo fmt --check` passes
- [x] `cargo check` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracted duplicated tag/author/path/priority filtering logic from `cmd/list.rs`, `cmd/search.rs`, and `cmd/tasks.rs` into a shared `cmd/filter.rs` module, eliminating ~85 lines of code duplication.

- New `FilterOptions` struct consolidates filter parameters
- New `apply_filters()` function provides single reusable implementation
- All three command modules now delegate to the shared function
- 8 comprehensive unit tests cover individual filters, combined filters, empty filters, and error handling
- Code is cleaner and more maintainable with a single source of truth for filter logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring that extracts duplicated logic into a well-tested shared module without changing behavior. The changes are purely structural with comprehensive test coverage and all existing tests passing.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cmd/filter.rs | New shared filter module with comprehensive unit tests covering all filter types |
| src/cmd/list.rs | Removed ~35 lines of duplicated filter logic, now delegates to apply_filters() |
| src/cmd/search.rs | Removed ~25 lines of duplicated filter logic, now delegates to apply_filters() |
| src/cmd/tasks.rs | Removed ~30 lines of duplicated filter logic, now delegates to apply_filters() |
| src/cmd/mod.rs | Added filter module declaration |

</details>



<sub>Last reviewed commit: e070666</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->