### PR TITLE
refactor(test): consolidate make_item() helpers into shared module

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -154,19 +154,7 @@ mod tests {
     use super::*;
     use crate::deadline::Deadline;
     use crate::model::{Priority, Tag};
-
-    fn make_item(file: &str, msg: &str) -> TodoItem {
-        TodoItem {
-            file: file.to_string(),
-            line: 1,
-            tag: Tag::Todo,
-            message: msg.to_string(),
-            author: None,
-            issue_ref: None,
-            priority: Priority::Normal,
-            deadline: None,
-        }
-    }
+    use crate::test_helpers::helpers::make_item;
 
     fn make_item_with_deadline(file: &str, msg: &str) -> TodoItem {
         TodoItem {
@@ -240,7 +228,7 @@ mod tests {
         cache.insert(
             PathBuf::from("src/main.rs"),
             *hash.as_bytes(),
-            vec![make_item("src/main.rs", "test task")],
+            vec![make_item("src/main.rs", 1, Tag::Todo, "test task")],
             mtime,
         );
 
@@ -318,7 +306,7 @@ mod tests {
         cache.insert(
             path.clone(),
             *hash.as_bytes(),
-            vec![make_item("test.rs", "cached")],
+            vec![make_item("test.rs", 1, Tag::Todo, "cached")],
             mtime,
         );
 
@@ -340,7 +328,7 @@ mod tests {
         cache.insert(
             path.clone(),
             *hash.as_bytes(),
-            vec![make_item("test.rs", "cached")],
+            vec![make_item("test.rs", 1, Tag::Todo, "cached")],
             mtime,
         );
 
@@ -359,7 +347,7 @@ mod tests {
         cache.insert(
             path.clone(),
             *hash.as_bytes(),
-            vec![make_item("test.rs", "test content")],
+            vec![make_item("test.rs", 1, Tag::Todo, "test content")],
             mtime,
         );
 
@@ -380,7 +368,7 @@ mod tests {
         cache.insert(
             path.clone(),
             *hash.as_bytes(),
-            vec![make_item("test.rs", "original")],
+            vec![make_item("test.rs", 1, Tag::Todo, "original")],
             mtime,
         );
 
@@ -399,13 +387,13 @@ mod tests {
         cache.insert(
             PathBuf::from("keep.rs"),
             *hash.as_bytes(),
-            vec![make_item("keep.rs", "keep")],
+            vec![make_item("keep.rs", 1, Tag::Todo, "keep")],
             mtime,
         );
         cache.insert(
             PathBuf::from("delete.rs"),
             *hash.as_bytes(),
-            vec![make_item("delete.rs", "delete")],
+            vec![make_item("delete.rs", 1, Tag::Todo, "delete")],
             mtime,
         );
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -100,20 +100,8 @@ pub fn run_check(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{Priority, Tag};
-
-    fn make_item(file: &str, line: usize, tag: Tag, message: &str) -> TodoItem {
-        TodoItem {
-            file: file.to_string(),
-            line,
-            tag,
-            message: message.to_string(),
-            author: None,
-            issue_ref: None,
-            priority: Priority::Normal,
-            deadline: None,
-        }
-    }
+    use crate::model::Tag;
+    use crate::test_helpers::helpers::make_item;
 
     fn default_overrides() -> CheckOverrides {
         CheckOverrides {

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -290,18 +290,7 @@ mod tests {
         }
     }
 
-    fn make_item(file: &str, line: usize, tag: Tag, message: &str) -> TodoItem {
-        TodoItem {
-            file: file.to_string(),
-            line,
-            tag,
-            message: message.to_string(),
-            author: None,
-            issue_ref: None,
-            priority: Priority::Normal,
-            deadline: None,
-        }
-    }
+    use crate::test_helpers::helpers::make_item;
 
     fn make_item_with_issue(
         file: &str,

--- a/src/cmd/filter.rs
+++ b/src/cmd/filter.rs
@@ -48,26 +48,26 @@ pub fn apply_filters(items: &mut Vec<TodoItem>, filters: &FilterOptions) -> Resu
 mod tests {
     use super::*;
     use crate::model::{Priority, Tag, TodoItem};
+    use crate::test_helpers::helpers::make_item;
 
-    fn make_item(file: &str, tag: Tag, priority: Priority, author: Option<&str>) -> TodoItem {
-        TodoItem {
-            file: file.to_string(),
-            line: 1,
-            tag,
-            message: "test".to_string(),
-            author: author.map(|a| a.to_string()),
-            issue_ref: None,
-            priority,
-            deadline: None,
-        }
+    fn make_filter_item(
+        file: &str,
+        tag: Tag,
+        priority: Priority,
+        author: Option<&str>,
+    ) -> TodoItem {
+        let mut item = make_item(file, 1, tag, "test");
+        item.priority = priority;
+        item.author = author.map(|a| a.to_string());
+        item
     }
 
     #[test]
     fn filter_by_tag() {
         let mut items = vec![
-            make_item("a.rs", Tag::Todo, Priority::Normal, None),
-            make_item("b.rs", Tag::Fixme, Priority::Normal, None),
-            make_item("c.rs", Tag::Hack, Priority::Normal, None),
+            make_filter_item("a.rs", Tag::Todo, Priority::Normal, None),
+            make_filter_item("b.rs", Tag::Fixme, Priority::Normal, None),
+            make_filter_item("c.rs", Tag::Hack, Priority::Normal, None),
         ];
         let filters = FilterOptions {
             tags: vec!["TODO".to_string()],
@@ -83,9 +83,9 @@ mod tests {
     #[test]
     fn filter_by_multiple_tags() {
         let mut items = vec![
-            make_item("a.rs", Tag::Todo, Priority::Normal, None),
-            make_item("b.rs", Tag::Fixme, Priority::Normal, None),
-            make_item("c.rs", Tag::Hack, Priority::Normal, None),
+            make_filter_item("a.rs", Tag::Todo, Priority::Normal, None),
+            make_filter_item("b.rs", Tag::Fixme, Priority::Normal, None),
+            make_filter_item("c.rs", Tag::Hack, Priority::Normal, None),
         ];
         let filters = FilterOptions {
             tags: vec!["TODO".to_string(), "HACK".to_string()],
@@ -102,9 +102,9 @@ mod tests {
     #[test]
     fn filter_by_priority() {
         let mut items = vec![
-            make_item("a.rs", Tag::Todo, Priority::Normal, None),
-            make_item("b.rs", Tag::Todo, Priority::High, None),
-            make_item("c.rs", Tag::Todo, Priority::Urgent, None),
+            make_filter_item("a.rs", Tag::Todo, Priority::Normal, None),
+            make_filter_item("b.rs", Tag::Todo, Priority::High, None),
+            make_filter_item("c.rs", Tag::Todo, Priority::Urgent, None),
         ];
         let filters = FilterOptions {
             tags: vec![],
@@ -120,9 +120,9 @@ mod tests {
     #[test]
     fn filter_by_author() {
         let mut items = vec![
-            make_item("a.rs", Tag::Todo, Priority::Normal, Some("alice")),
-            make_item("b.rs", Tag::Todo, Priority::Normal, Some("bob")),
-            make_item("c.rs", Tag::Todo, Priority::Normal, None),
+            make_filter_item("a.rs", Tag::Todo, Priority::Normal, Some("alice")),
+            make_filter_item("b.rs", Tag::Todo, Priority::Normal, Some("bob")),
+            make_filter_item("c.rs", Tag::Todo, Priority::Normal, None),
         ];
         let filters = FilterOptions {
             tags: vec![],
@@ -138,9 +138,9 @@ mod tests {
     #[test]
     fn filter_by_path() {
         let mut items = vec![
-            make_item("src/main.rs", Tag::Todo, Priority::Normal, None),
-            make_item("src/lib.rs", Tag::Todo, Priority::Normal, None),
-            make_item("tests/test.rs", Tag::Todo, Priority::Normal, None),
+            make_filter_item("src/main.rs", Tag::Todo, Priority::Normal, None),
+            make_filter_item("src/lib.rs", Tag::Todo, Priority::Normal, None),
+            make_filter_item("tests/test.rs", Tag::Todo, Priority::Normal, None),
         ];
         let filters = FilterOptions {
             tags: vec![],
@@ -156,10 +156,10 @@ mod tests {
     #[test]
     fn filter_combined() {
         let mut items = vec![
-            make_item("src/main.rs", Tag::Todo, Priority::High, Some("alice")),
-            make_item("src/lib.rs", Tag::Fixme, Priority::Normal, Some("alice")),
-            make_item("tests/test.rs", Tag::Todo, Priority::High, Some("bob")),
-            make_item("src/util.rs", Tag::Todo, Priority::Normal, Some("alice")),
+            make_filter_item("src/main.rs", Tag::Todo, Priority::High, Some("alice")),
+            make_filter_item("src/lib.rs", Tag::Fixme, Priority::Normal, Some("alice")),
+            make_filter_item("tests/test.rs", Tag::Todo, Priority::High, Some("bob")),
+            make_filter_item("src/util.rs", Tag::Todo, Priority::Normal, Some("alice")),
         ];
         let filters = FilterOptions {
             tags: vec!["TODO".to_string()],
@@ -175,8 +175,8 @@ mod tests {
     #[test]
     fn empty_filters_retain_all() {
         let mut items = vec![
-            make_item("a.rs", Tag::Todo, Priority::Normal, None),
-            make_item("b.rs", Tag::Fixme, Priority::High, Some("alice")),
+            make_filter_item("a.rs", Tag::Todo, Priority::Normal, None),
+            make_filter_item("b.rs", Tag::Fixme, Priority::High, Some("alice")),
         ];
         let filters = FilterOptions {
             tags: vec![],
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn invalid_glob_returns_error() {
-        let mut items = vec![make_item("a.rs", Tag::Todo, Priority::Normal, None)];
+        let mut items = vec![make_filter_item("a.rs", Tag::Todo, Priority::Normal, None)];
         let filters = FilterOptions {
             tags: vec![],
             author: None,

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -227,20 +227,8 @@ fn check_raw_text_rules(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{Priority, Tag};
-
-    fn make_item(file: &str, line: usize, tag: Tag, message: &str) -> TodoItem {
-        TodoItem {
-            file: file.to_string(),
-            line,
-            tag,
-            message: message.to_string(),
-            author: None,
-            issue_ref: None,
-            priority: Priority::Normal,
-            deadline: None,
-        }
-    }
+    use crate::model::Tag;
+    use crate::test_helpers::helpers::make_item;
 
     fn default_overrides() -> LintOverrides {
         LintOverrides {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ mod scanner;
 mod search;
 mod stats;
 mod tasks;
+#[cfg(test)]
+mod test_helpers;
 mod watch;
 mod workspace;
 

--- a/src/relate.rs
+++ b/src/relate.rs
@@ -358,19 +358,7 @@ pub fn build_clusters(relationships: &[Relationship], items: &[TodoItem]) -> Vec
 mod tests {
     use super::*;
     use crate::model::{Priority, Tag};
-
-    fn make_item(file: &str, line: usize, tag: Tag, message: &str) -> TodoItem {
-        TodoItem {
-            file: file.to_string(),
-            line,
-            tag,
-            message: message.to_string(),
-            author: None,
-            issue_ref: None,
-            priority: Priority::Normal,
-            deadline: None,
-        }
-    }
+    use crate::test_helpers::helpers::make_item;
 
     // --- extract_keywords ---
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -79,19 +79,7 @@ pub fn compute_stats(scan: &ScanResult, diff: Option<&DiffResult>) -> StatsResul
 mod tests {
     use super::*;
     use crate::model::{Priority, Tag};
-
-    fn make_item(file: &str, line: usize, tag: Tag, message: &str) -> TodoItem {
-        TodoItem {
-            file: file.to_string(),
-            line,
-            tag,
-            message: message.to_string(),
-            author: None,
-            issue_ref: None,
-            priority: Priority::Normal,
-            deadline: None,
-        }
-    }
+    use crate::test_helpers::helpers::make_item;
 
     #[test]
     fn test_basic_counts() {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -145,18 +145,7 @@ mod tests {
     use crate::context::ContextLine;
     use crate::model::Priority;
 
-    fn make_item(tag: Tag, message: &str) -> TodoItem {
-        TodoItem {
-            file: "src/main.rs".to_string(),
-            line: 10,
-            tag,
-            message: message.to_string(),
-            author: None,
-            issue_ref: None,
-            priority: Priority::Normal,
-            deadline: None,
-        }
-    }
+    use crate::test_helpers::helpers::make_item;
 
     #[test]
     fn test_action_verb_mapping() {
@@ -180,31 +169,31 @@ mod tests {
 
     #[test]
     fn test_build_subject_with_message() {
-        let item = make_item(Tag::Todo, "add user validation");
+        let item = make_item("src/main.rs", 10, Tag::Todo, "add user validation");
         assert_eq!(build_subject(&item), "Implement add user validation");
     }
 
     #[test]
     fn test_build_subject_empty_message() {
-        let item = make_item(Tag::Bug, "");
+        let item = make_item("src/main.rs", 10, Tag::Bug, "");
         assert_eq!(build_subject(&item), "Fix BUG at src/main.rs:10");
     }
 
     #[test]
     fn test_build_active_form_with_message() {
-        let item = make_item(Tag::Hack, "remove workaround");
+        let item = make_item("src/main.rs", 10, Tag::Hack, "remove workaround");
         assert_eq!(build_active_form(&item), "Refactoring remove workaround");
     }
 
     #[test]
     fn test_build_active_form_empty_message() {
-        let item = make_item(Tag::Fixme, "");
+        let item = make_item("src/main.rs", 10, Tag::Fixme, "");
         assert_eq!(build_active_form(&item), "Fixing FIXME at src/main.rs:10");
     }
 
     #[test]
     fn test_build_description_basic() {
-        let item = make_item(Tag::Todo, "implement feature");
+        let item = make_item("src/main.rs", 10, Tag::Todo, "implement feature");
         let desc = build_description(&item, None);
         assert!(desc.contains("**[TODO]** `src/main.rs:10`"));
         assert!(desc.contains("implement feature"));
@@ -213,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_build_description_with_author_and_issue() {
-        let mut item = make_item(Tag::Bug, "critical crash");
+        let mut item = make_item("src/main.rs", 10, Tag::Bug, "critical crash");
         item.author = Some("alice".to_string());
         item.issue_ref = Some("#42".to_string());
         item.priority = Priority::Urgent;
@@ -226,7 +215,7 @@ mod tests {
 
     #[test]
     fn test_build_description_with_context() {
-        let item = make_item(Tag::Todo, "fix this");
+        let item = make_item("src/main.rs", 10, Tag::Todo, "fix this");
         let ctx = ContextInfo {
             before: vec![ContextLine {
                 line_number: 9,
@@ -246,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_build_tasks_metadata() {
-        let mut item = make_item(Tag::Bug, "fix crash");
+        let mut item = make_item("src/main.rs", 10, Tag::Bug, "fix crash");
         item.author = Some("bob".to_string());
         item.issue_ref = Some("#99".to_string());
 
@@ -267,17 +256,17 @@ mod tests {
     fn test_sort_by_priority_ordering() {
         let mut items = vec![
             {
-                let mut i = make_item(Tag::Note, "low");
+                let mut i = make_item("src/main.rs", 10, Tag::Note, "low");
                 i.priority = Priority::Normal;
                 i
             },
             {
-                let mut i = make_item(Tag::Bug, "critical");
+                let mut i = make_item("src/main.rs", 10, Tag::Bug, "critical");
                 i.priority = Priority::Urgent;
                 i
             },
             {
-                let mut i = make_item(Tag::Todo, "medium");
+                let mut i = make_item("src/main.rs", 10, Tag::Todo, "medium");
                 i.priority = Priority::High;
                 i
             },
@@ -293,9 +282,9 @@ mod tests {
     #[test]
     fn test_sort_by_priority_same_priority_uses_tag_severity() {
         let mut items = vec![
-            make_item(Tag::Note, "note item"),
-            make_item(Tag::Bug, "bug item"),
-            make_item(Tag::Todo, "todo item"),
+            make_item("src/main.rs", 10, Tag::Note, "note item"),
+            make_item("src/main.rs", 10, Tag::Bug, "bug item"),
+            make_item("src/main.rs", 10, Tag::Todo, "todo item"),
         ];
 
         sort_by_priority(&mut items);

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,17 @@
+#[cfg(test)]
+pub mod helpers {
+    use crate::model::{Priority, Tag, TodoItem};
+
+    pub fn make_item(file: &str, line: usize, tag: Tag, message: &str) -> TodoItem {
+        TodoItem {
+            file: file.to_string(),
+            line,
+            tag,
+            message: message.to_string(),
+            author: None,
+            issue_ref: None,
+            priority: Priority::Normal,
+            deadline: None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract duplicated `make_item()` test helper from 9 files into a single shared `src/test_helpers.rs` module
- Files with identical 4-argument signatures (`relate`, `stats`, `lint`, `check`, `clean`) use the shared helper directly
- Files with different signatures (`cache`, `tasks`, `search`, `cmd/filter`) have call sites adapted to the unified signature
- Net reduction of 71 lines (96 added, 167 removed)

Closes #93

## Test Plan

- [x] All 296 unit tests pass (`cargo test`)
- [x] All integration tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo check` clean (no warnings)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracted duplicated `make_item()` test helper from 9 test modules into a single shared `src/test_helpers.rs` module, reducing code duplication by 71 lines. Files with identical 4-argument signatures now use the shared helper directly, while files with different signatures (`cache`, `tasks`, `search`, `cmd/filter`) had their call sites adapted to the unified signature.

**Key changes:**
- Created new `src/test_helpers.rs` with standardized 4-arg `make_item(file, line, tag, message)` helper
- Removed 9 duplicate `make_item()` implementations across test modules
- Files with non-standard signatures adapted using either direct call-site updates or wrapper functions (`make_filter_item` in `cmd/filter.rs`)
- All 296 tests reported passing per PR description

<h3>Confidence Score: 5/5</h3>

- Safe to merge - test-only refactoring with no production code changes
- This is a pure test code refactoring that consolidates duplicate helper functions. The changes are mechanical, well-structured, and all tests pass. No production code is affected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/test_helpers.rs | New shared module for `make_item()` test helper with 4-argument signature |
| src/main.rs | Added `#[cfg(test)]` module declaration for `test_helpers` |
| src/cache.rs | Replaced local `make_item()` with shared helper, updated call sites to 4-arg signature |
| src/search.rs | Replaced 3-arg `make_item()` with 4-arg shared helper, adapted call sites |
| src/tasks.rs | Replaced 2-arg `make_item()` with 4-arg shared helper, adapted all call sites |
| src/cmd/filter.rs | Replaced custom `make_item()` with shared helper, introduced `make_filter_item()` wrapper |

</details>



<sub>Last reviewed commit: 416b27d</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=222a0453-b647-4f29-b563-3e55a457947c))

<!-- /greptile_comment -->