### PR TITLE
feat(scanner): add todox:ignore inline suppression comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Track TODO/FIXME/HACK comments in your codebase with git-aware diff and CI gate.
 2. **Analyze**
      - [Diff Against Git Refs](#diff-against-git-refs) · [Dashboard & Statistics](#dashboard--statistics) · [Git Blame Integration](#git-blame-integration) · [Discover TODO Relationships](#discover-todo-relationships)
 3. **Enforce**
-     - [Lint TODO Format](#lint-todo-format) · [Clean Stale & Duplicate TODOs](#clean-stale--duplicate-todos) · [CI Quality Gate](#ci-quality-gate)
+     - [Inline Suppression](#inline-suppression) · [Lint TODO Format](#lint-todo-format) · [Clean Stale & Duplicate TODOs](#clean-stale--duplicate-todos) · [CI Quality Gate](#ci-quality-gate)
 4. **Scale**
      - [Workspace-Aware Scanning](#workspace-aware-scanning) · [Per-Package CI Gate](#per-package-ci-gate) · [Single Package Scope](#single-package-scope)
 5. **Report & Integrate**
@@ -155,6 +155,27 @@ Related TODOs surface as actionable clusters, revealing hidden patterns in your 
 
 ```sh
 todox relate --cluster
+```
+
+### Inline Suppression
+
+🔥 **Problem**
+
+Some TODO comments are intentional or false positives, but the only way to exclude them is file-level patterns in `.todox.toml`, which is too coarse.
+
+🌱 **Solution**
+
+Add `todox:ignore` at the end of a TODO line to suppress that specific item, or place `todox:ignore-next-line` on the line above to suppress the following TODO. Suppressed items are excluded from counts, checks, and output by default. Use `--show-ignored` to reveal them.
+
+🎁 **Outcome**
+
+You get fine-grained, inline control over false positives without maintaining exclusion lists in config files.
+
+```
+// TODO: this is tracked normally
+// TODO: known false positive todox:ignore
+// todox:ignore-next-line
+// FIXME: suppressed item
 ```
 
 ### Lint TODO Format
@@ -385,6 +406,9 @@ Tags: `TODO`, `FIXME`, `HACK`, `XXX`, `BUG`, `NOTE` (case-insensitive)
 // HACK(bob): workaround for JIRA-456   ← author + issue ref
 // TODO(2025-06-01): migrate to v2 API   ← deadline (YYYY-MM-DD)
 // TODO(alice, 2025-Q2): refactor auth   ← author + deadline (quarter)
+// TODO: false positive todox:ignore     ← suppressed from output
+// todox:ignore-next-line                ← suppresses the line below
+// FIXME: suppressed item
 ```
 
 ### Supported comment syntax
@@ -724,6 +748,7 @@ todox tasks --dry-run --format json
 | `--root <path>` | Set the project root directory (default: current directory) |
 | `--format <format>` | Output format: `text`, `json`, `github-actions`, `sarif`, `markdown` (default: text) |
 | `--config <path>` | Path to config file (default: auto-discover `.todox.toml`) |
+| `--show-ignored` | Show items suppressed by `todox:ignore` markers |
 
 ### Output formats
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -125,6 +125,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "do something")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let config = Config::default();
         let overrides = CheckOverrides {
@@ -146,6 +147,7 @@ mod tests {
         let scan = ScanResult {
             items,
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let config = Config::default();
         let overrides = CheckOverrides {
@@ -169,6 +171,7 @@ mod tests {
                 make_item("b.rs", 5, Tag::Todo, "normal todo"),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
         let config = Config::default();
         let overrides = CheckOverrides {
@@ -189,6 +192,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "new todo")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let diff = DiffResult {
             entries: vec![DiffEntry {
@@ -221,6 +225,7 @@ mod tests {
                 make_item("b.rs", 2, Tag::Note, "just a note"),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
         let config = Config::default();
         let overrides = default_overrides();
@@ -242,6 +247,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![item],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let config = Config::default();
         let overrides = CheckOverrides {
@@ -267,6 +273,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![item],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let config = Config::default();
         let overrides = CheckOverrides {
@@ -290,6 +297,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![item],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let config = Config::default();
         let overrides = default_overrides(); // expired: false

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -328,6 +328,7 @@ mod tests {
                 "#42",
             )],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let checker =
             MockIssueChecker::new(vec![(42, Some(IssueState::Closed { closed_at: None }))]);
@@ -349,6 +350,7 @@ mod tests {
                 "#42",
             )],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let checker = MockIssueChecker::new(vec![(42, Some(IssueState::Open))]);
         let result = run_clean(&scan, &default_config(), Some(&checker), None);
@@ -375,6 +377,7 @@ mod tests {
                 "#42",
             )],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let checker = MockIssueChecker::new(vec![(
             42,
@@ -408,6 +411,7 @@ mod tests {
                 "#42",
             )],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let checker = MockIssueChecker::new(vec![(
             42,
@@ -430,6 +434,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![item],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let checker = MockIssueChecker::new(vec![]);
         let result = run_clean(&scan, &default_config(), Some(&checker), None);
@@ -448,6 +453,7 @@ mod tests {
                 "#42",
             )],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let result = run_clean(&scan, &default_config(), None, None);
         assert!(result.passed);
@@ -464,6 +470,7 @@ mod tests {
                 make_item("b.rs", 5, Tag::Todo, "implement feature"),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
         let result = run_clean(&scan, &default_config(), None, None);
         assert!(!result.passed);
@@ -479,6 +486,7 @@ mod tests {
                 make_item("b.rs", 5, Tag::Todo, "implement feature"),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
         let result = run_clean(&scan, &default_config(), None, None);
         assert!(!result.passed);
@@ -493,6 +501,7 @@ mod tests {
                 make_item("b.rs", 5, Tag::Todo, "implement feature"),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
         let result = run_clean(&scan, &default_config(), None, None);
         assert!(!result.passed);
@@ -507,6 +516,7 @@ mod tests {
                 make_item("b.rs", 5, Tag::Todo, "implement feature B"),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
         let result = run_clean(&scan, &default_config(), None, None);
         assert!(result.passed);
@@ -521,6 +531,7 @@ mod tests {
                 make_item("b.rs", 5, Tag::Todo, ""),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
         let result = run_clean(&scan, &default_config(), None, None);
         assert!(result.passed);
@@ -532,6 +543,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "unique message")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let result = run_clean(&scan, &default_config(), None, None);
         assert!(result.passed);
@@ -569,6 +581,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item_with_issue("a.rs", 1, Tag::Todo, "fix #42", "#42")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let checker =
             MockIssueChecker::new(vec![(42, Some(IssueState::Closed { closed_at: None }))]);
@@ -586,6 +599,7 @@ mod tests {
                 make_item("b.rs", 2, Tag::Todo, "same message"),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
         let mut config = default_config();
         config.clean.duplicates = Some(false);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_cache: bool,
 
+    /// Show items suppressed by todox:ignore markers
+    #[arg(long, global = true)]
+    pub show_ignored: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -20,6 +20,7 @@ pub struct ListOptions {
     pub path: Option<String>,
     pub limit: Option<usize>,
     pub context: Option<usize>,
+    pub show_ignored: bool,
 }
 
 pub fn cmd_list(
@@ -30,6 +31,8 @@ pub fn cmd_list(
     no_cache: bool,
 ) -> Result<()> {
     let mut result = do_scan(root, config, no_cache)?;
+
+    let ignored_count = result.ignored_items.len();
 
     apply_filters(
         &mut result.items,
@@ -73,6 +76,13 @@ pub fn cmd_list(
         HashMap::new()
     };
 
-    print_list(&result, format, &opts.group_by, &context_map);
+    print_list(
+        &result,
+        format,
+        &opts.group_by,
+        &context_map,
+        ignored_count,
+        opts.show_ignored,
+    );
     Ok(())
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -83,8 +83,8 @@ pub fn compute_diff(
             Err(_) => continue, // skip binary or inaccessible files
         };
 
-        let items = scan_content(&content, path, &re);
-        base_items.extend(items);
+        let result = scan_content(&content, path, &re);
+        base_items.extend(result.items);
     }
 
     // Only compare current items from changed files

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -246,6 +246,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let config = Config::default();
         let overrides = default_overrides();
@@ -260,6 +261,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "real message")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.uppercase_tag = Some(false);
@@ -274,6 +276,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "this is a long message")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -293,6 +296,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "no author")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -314,6 +318,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![item],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -332,6 +337,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Bug, "no issue ref")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -353,6 +359,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![item],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -371,6 +378,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Note, "just a note")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -393,6 +401,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("test.rs", 1, Tag::Todo, "lowercase tag")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -415,6 +424,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("test.rs", 1, Tag::Todo, "uppercase tag")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -436,6 +446,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("test.rs", 1, Tag::Todo, "fix without colon")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -458,6 +469,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("test.rs", 1, Tag::Todo, "fix with colon")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false);
@@ -475,6 +487,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "valid message")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         // Disable all default-true rules via config
@@ -491,6 +504,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.no_bare_tags = Some(false); // Config disables
@@ -513,6 +527,7 @@ mod tests {
                 make_item("a.rs", 2, Tag::Bug, "no issue ref"),
             ],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let mut config = Config::default();
         config.lint.uppercase_tag = Some(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,7 @@ fn run() -> Result<()> {
                         path,
                         limit,
                         context,
+                        show_ignored: cli.show_ignored,
                     };
                     let scan_root = resolve_package_root(&root, &config, package.as_deref())?;
                     cmd_list(&scan_root, &config, &cli.format, opts, no_cache)

--- a/src/model.rs
+++ b/src/model.rs
@@ -114,6 +114,8 @@ impl TodoItem {
 #[derive(Debug, Serialize)]
 pub struct ScanResult {
     pub items: Vec<TodoItem>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ignored_items: Vec<TodoItem>,
     pub files_scanned: usize,
 }
 

--- a/src/output/github_actions.rs
+++ b/src/output/github_actions.rs
@@ -184,6 +184,7 @@ mod tests {
         let result = ScanResult {
             items: vec![sample_item(Tag::Todo, "implement feature")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         assert!(output
@@ -199,6 +200,7 @@ mod tests {
                 sample_item(Tag::Note, "a note"),
             ],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         assert!(output.contains("::error file=src/main.rs,line=10,title=BUG::[BUG] critical bug"));
@@ -219,6 +221,7 @@ mod tests {
                 deadline: None,
             }],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         assert!(output.contains("::error file=lib.rs,line=5,title=TODO::[TODO] urgent task"));
@@ -229,6 +232,7 @@ mod tests {
         let result = ScanResult {
             items: vec![sample_item(Tag::Todo, "fix 100% of bugs\nline2")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         assert!(output.contains("fix 100%25 of bugs%0Aline2"));

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -258,6 +258,7 @@ mod tests {
         let result = ScanResult {
             items: vec![],
             files_scanned: 0,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         assert!(output
@@ -279,6 +280,7 @@ mod tests {
                 deadline: None,
             }],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         assert!(output.contains("| lib.rs | 42 | TODO | ! | add tests | alice | #123 |  |"));
@@ -290,6 +292,7 @@ mod tests {
         let result = ScanResult {
             items: vec![sample_item(Tag::Todo, "a | b")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         assert!(output.contains("a \\| b"));

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -402,6 +402,7 @@ mod tests {
         let result = ScanResult {
             items: vec![sample_item(Tag::Todo, "implement feature")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         let sarif: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -432,6 +433,7 @@ mod tests {
                 sample_item(Tag::Note, "info"),
             ],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         let sarif: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -449,6 +451,7 @@ mod tests {
                 sample_item(Tag::Bug, "a bug"),
             ],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let output = format_list(&result);
         let sarif: serde_json::Value = serde_json::from_str(&output).unwrap();

--- a/src/relate.rs
+++ b/src/relate.rs
@@ -514,6 +514,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![],
             files_scanned: 0,
+            ignored_items: vec![],
         };
         let result = compute_relations(&scan, 0.3, 10);
         assert!(result.relationships.is_empty());
@@ -525,6 +526,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("src/main.rs", 10, Tag::Todo, "fix something")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let result = compute_relations(&scan, 0.3, 10);
         assert!(result.relationships.is_empty());
@@ -539,6 +541,7 @@ mod tests {
                 make_item("src/main.rs", 12, Tag::Fixme, "broken authentication"),
             ],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         // With min_score=0.0, should find relationship
         let result_low = compute_relations(&scan, 0.0, 10);

--- a/src/report.rs
+++ b/src/report.rs
@@ -127,7 +127,7 @@ pub fn compute_history(
                 Err(_) => continue,
             };
 
-            count += scan_content(&content, file_path, &pattern).len();
+            count += scan_content(&content, file_path, &pattern).items.len();
         }
 
         history.push(HistoryPoint {

--- a/src/search.rs
+++ b/src/search.rs
@@ -44,6 +44,7 @@ mod tests {
     fn make_scan(items: Vec<TodoItem>) -> ScanResult {
         ScanResult {
             files_scanned: 1,
+            ignored_items: vec![],
             items,
         }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -90,6 +90,7 @@ mod tests {
                 make_item("b.rs", 1, Tag::Fixme, "fix this"),
             ],
             files_scanned: 2,
+            ignored_items: vec![],
         };
 
         let result = compute_stats(&scan, None);
@@ -112,6 +113,7 @@ mod tests {
         let scan = ScanResult {
             items,
             files_scanned: 1,
+            ignored_items: vec![],
         };
 
         let result = compute_stats(&scan, None);
@@ -133,6 +135,7 @@ mod tests {
         let scan = ScanResult {
             items,
             files_scanned: 1,
+            ignored_items: vec![],
         };
 
         let result = compute_stats(&scan, None);
@@ -148,6 +151,7 @@ mod tests {
         let scan = ScanResult {
             items,
             files_scanned: 10,
+            ignored_items: vec![],
         };
 
         let result = compute_stats(&scan, None);
@@ -159,6 +163,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![make_item("a.rs", 1, Tag::Todo, "task")],
             files_scanned: 1,
+            ignored_items: vec![],
         };
         let diff = DiffResult {
             entries: vec![],
@@ -180,6 +185,7 @@ mod tests {
         let scan = ScanResult {
             items: vec![],
             files_scanned: 0,
+            ignored_items: vec![],
         };
 
         let result = compute_stats(&scan, None);

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -55,7 +55,8 @@ impl TodoIndex {
         let content = std::fs::read_to_string(&abs_path)
             .with_context(|| format!("failed to read {}", abs_path.display()))?;
 
-        let new_items = scan_content(&content, relative_path, &self.pattern);
+        let scan_result = scan_content(&content, relative_path, &self.pattern);
+        let new_items = scan_result.items;
         let old_items = self.items.remove(relative_path).unwrap_or_default();
 
         let old_keys: HashMap<String, &TodoItem> =

--- a/tests/integration_check.rs
+++ b/tests/integration_check.rs
@@ -285,3 +285,43 @@ fn test_check_expired_quarter_format() {
         .stdout(predicate::str::contains("FAIL"))
         .stdout(predicate::str::contains("expired"));
 }
+
+#[test]
+fn test_check_max_does_not_count_ignored() {
+    // 3 TODOs total, but 1 is ignored via todox:ignore
+    // So effective count is 2, which should pass --max 2
+    let dir = setup_project(&[(
+        "main.rs",
+        "// TODO: one\n// TODO: two\n// TODO: three todox:ignore\n",
+    )]);
+
+    todox()
+        .args([
+            "check",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--max",
+            "2",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+}
+
+#[test]
+fn test_check_max_fails_without_ignore() {
+    // Same content but without todox:ignore - should fail --max 2
+    let dir = setup_project(&[("main.rs", "// TODO: one\n// TODO: two\n// TODO: three\n")]);
+
+    todox()
+        .args([
+            "check",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--max",
+            "2",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("FAIL"));
+}


### PR DESCRIPTION
## Summary

Add `todox:ignore` and `todox:ignore-next-line` inline comment markers to suppress individual TODO items from scan results, similar to `eslint-disable-next-line`. Suppressed items are excluded from counts, checks, and output by default.

- **`todox:ignore`** at end of a TODO line suppresses that item
- **`todox:ignore-next-line`** on its own line suppresses the following TODO
- **`--show-ignored`** global flag reveals suppressed items
- Suppressed items do not count toward `--max` threshold in `todox check`

Closes #75

## Test Plan

- [x] Unit tests added (8 tests in `scanner.rs`: inline ignore, next-line ignore, blank line gap, mixed items, message stripping)
- [x] Integration tests added (5 in `integration_list.rs`, 2 in `integration_check.rs`)
- [x] Manual testing completed (`todox list --root . --no-cache` and `--show-ignored`)
- [x] All 304+ tests pass, `cargo fmt --check` and `cargo check` clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds inline suppression markers `todox:ignore` and `todox:ignore-next-line` to exclude individual TODO items from scan results. Suppressed items are tracked separately in `ScanResult.ignored_items` and excluded from counts/checks by default. The `--show-ignored` global flag reveals suppressed items in output.

- Core implementation in `scanner.rs` pre-scans for next-line markers and checks both inline and next-line suppression during pattern matching
- Cache layer extended to store both items and ignored items separately with backward compatibility via `#[serde(default)]`
- Suppressed items don't count toward `--max` threshold in `todox check`, enabling selective suppression
- Comprehensive test coverage: 8 unit tests in scanner, 5 integration tests for list, 2 for check
- Clean separation of concerns across model, cache, CLI, output formatting layers
- All 304+ existing tests pass

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-architected feature with excellent test coverage (15 new tests), clean separation of ignored items throughout the codebase, backward-compatible cache changes, and all existing tests passing. The implementation is straightforward, thoroughly tested, and follows established patterns in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/scanner.rs | Implements `todox:ignore` and `todox:ignore-next-line` suppression markers with proper separation of ignored items. Comprehensive unit tests added (8 tests). Logic is sound and well-tested. |
| src/model.rs | Adds `ignored_items` field to `ScanResult` with conditional serialization. Minimal, clean change. |
| src/cache.rs | Extends cache to store both items and ignored items. Adds `CacheCheckResult` struct for returning both. Backward compatible via `#[serde(default)]`. All tests updated. |
| src/cmd/list.rs | Threads `show_ignored` flag and `ignored_count` to output functions. Clean integration. |
| src/output/mod.rs | Adds ignored items section when `--show-ignored` is set, displays dimmed. Shows ignored count in summary line. Well-formatted output changes. |
| tests/integration_list.rs | Adds 5 integration tests for ignore functionality: default behavior, `--show-ignored`, next-line suppression, no ignored case, message stripping. Good coverage. |
| tests/integration_check.rs | Adds tests verifying ignored items don't count toward `--max` threshold. Critical functionality well-tested. |

</details>



<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scan_content] -->|Pre-scan| B[Find todox:ignore-next-line markers]
    B --> C[Build suppressed_lines HashSet]
    A --> D[Iterate through lines]
    D --> E{Pattern match?}
    E -->|No| D
    E -->|Yes| F[Extract TODO item]
    F --> G{Check suppression}
    G -->|has_inline_ignore?| H[Strip marker from message]
    G -->|is_next_line_suppressed?| H
    G --> I{is_suppressed?}
    I -->|Yes| J[Add to ignored_items]
    I -->|No| K[Add to items]
    H --> I
    J --> D
    K --> D
    D -->|Done| L[Return ScanContentResult]
    L --> M[Cache stores both items + ignored_items]
    M --> N[Filter by --show-ignored flag]
    N -->|false| O[Display items only + count]
    N -->|true| P[Display items + ignored section]
```
</details>


<sub>Last reviewed commit: b4292e0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->