### PR TITLE
feat(output): expose stable TODO IDs in all output formats

### DIFF
--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use crate::cli::Format;
 use crate::config::Config;
-use crate::context::{build_rich_context, parse_location};
+use crate::context::{build_rich_context, resolve_location};
 use crate::model;
 use crate::output::print_context;
 
@@ -18,10 +18,10 @@ pub fn cmd_context(
     n: usize,
     no_cache: bool,
 ) -> Result<()> {
-    let (file, line) = parse_location(location)?;
-
-    // Scan to find related TODOs in the same file
+    // Scan first so we have items available for ID-based resolution
     let scan = do_scan(root, config, no_cache)?;
+    let (file, line) = resolve_location(location, &scan.items)?;
+
     let todos_in_file: Vec<&model::TodoItem> =
         scan.items.iter().filter(|i| i.file == file).collect();
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -109,6 +109,12 @@ impl TodoItem {
         let normalized = self.message.trim().to_lowercase();
         format!("{}:{}:{}", self.file, self.tag, normalized)
     }
+
+    /// Stable, content-based identifier for this TODO item.
+    /// Unlike `file:line`, this ID survives line-number changes from edits.
+    pub fn id(&self) -> String {
+        self.match_key()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -463,6 +469,21 @@ pub struct RelateResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn id_returns_same_value_as_match_key() {
+        let item = TodoItem {
+            file: "src/main.rs".to_string(),
+            line: 42,
+            tag: Tag::Todo,
+            message: "fix this bug".to_string(),
+            author: None,
+            issue_ref: None,
+            priority: Priority::Normal,
+            deadline: None,
+        };
+        assert_eq!(item.id(), item.match_key());
+    }
 
     #[test]
     fn priority_numeric_order_values() {

--- a/tests/integration_blame.rs
+++ b/tests/integration_blame.rs
@@ -276,3 +276,19 @@ fn test_blame_empty_repo() {
         .success()
         .stdout(predicate::str::contains("0 items"));
 }
+
+#[test]
+fn test_blame_json_contains_id_field() {
+    let dir = setup_git_repo(&[("main.rs", "// TODO: blame id test\nfn main() {}\n")]);
+    let cwd = dir.path();
+
+    let output = todox()
+        .args(["blame", "--root", cwd.to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let entry = &json["entries"][0];
+    assert_eq!(entry["id"].as_str().unwrap(), "main.rs:TODO:blame id test");
+}

--- a/tests/integration_context.rs
+++ b/tests/integration_context.rs
@@ -143,3 +143,24 @@ fn test_context_custom_window() {
         .stdout(predicate::str::contains("\"line_number\": 1").not())
         .stdout(predicate::str::contains("\"line_number\": 6").not());
 }
+
+#[test]
+fn test_context_resolves_stable_id() {
+    let dir = setup_project(&[(
+        "main.rs",
+        "fn main() {\n    let x = 1;\n    // TODO: fix this\n    let y = 2;\n}\n",
+    )]);
+
+    // Use the stable ID format instead of file:line
+    todox()
+        .args([
+            "context",
+            "main.rs:TODO:fix this",
+            "--root",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("main.rs:3"))
+        .stdout(predicate::str::contains("TODO: fix this"));
+}

--- a/tests/integration_search.rs
+++ b/tests/integration_search.rs
@@ -290,3 +290,25 @@ fn test_search_detail_minimal_json() {
         "issue_ref should not be in minimal search JSON"
     );
 }
+
+#[test]
+fn test_search_json_contains_id_field() {
+    let dir = setup_project(&[("main.rs", "// TODO: search id test\n// FIXME: other\n")]);
+
+    let output = todox()
+        .args([
+            "search",
+            "search id",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let item = &json["items"][0];
+    assert_eq!(item["id"].as_str().unwrap(), "main.rs:TODO:search id test");
+}


### PR DESCRIPTION
## Summary

- Add `TodoItem::id()` public method that delegates to `match_key()`, providing a stable content-based identifier that survives line-number changes
- Inject `id` field unconditionally in JSON output for list, diff, search, and blame commands
- Add `resolve_location()` function so `todox context` accepts both `file:line` and stable ID formats

Closes #99

## Test Plan

- [x] Unit test: `id()` returns same value as `match_key()`
- [x] Unit tests: `resolve_location()` with valid ID, fallback to file:line, and ID-takes-priority
- [x] Integration test: `id` field present in list JSON (normal and minimal detail)
- [x] Integration test: `id` and `match_key` both present in list JSON (full detail)
- [x] Integration test: `id` field present in diff JSON entries
- [x] Integration test: `id` field present in search JSON output
- [x] Integration test: `id` field present in blame JSON output
- [x] Integration test: `todox context <stable-id>` resolves correctly
- [x] All 308 existing tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added stable, content-based TODO identifiers that survive line-number changes across all JSON output formats and enabled ID-based location resolution in the context command.

- Exposed `TodoItem::id()` public method that delegates to `match_key()` 
- Injected `id` field unconditionally in JSON output for list, diff, search, and blame commands
- Added `resolve_location()` function allowing `todox context` to accept stable IDs (e.g., `main.rs:TODO:fix this`) in addition to traditional `file:line` format
- Maintained backward compatibility by keeping `match_key` in full detail mode
- Comprehensive test coverage: 10 new integration tests plus 3 unit tests validating ID functionality across all commands

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Implementation is clean, well-tested, and follows established patterns. All 308 existing tests pass, plus 13 new tests. The change is backward compatible and the refactoring in `apply_detail_to_json_item` properly centralizes ID generation logic.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/model.rs | Added `id()` method delegating to `match_key()` with test coverage |
| src/output/mod.rs | Injected `id` field in JSON output for all commands, `match_key` now copies from `id` in full detail mode |
| src/context.rs | Added `resolve_location()` to support stable ID resolution with fallback to file:line parsing |
| src/cmd/context.rs | Refactored to scan first, enabling ID-based location resolution in context command |

</details>



<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TodoItem] -->|match_key| B[Generate ID]
    B -->|file:tag:message| C[Stable ID String]
    
    D[JSON Output] -->|inject_id_field| C
    E[list/diff/search/blame] --> D
    
    F[context command] -->|resolve_location| G{ID or file:line?}
    G -->|Matches item.id| H[Return item file/line]
    G -->|No match| I[parse_location fallback]
    
    J[Detail Level] --> K{Full?}
    K -->|Yes| L[Add both id and match_key]
    K -->|No| M[Add id only]
```
</details>


<sub>Last reviewed commit: 1727bda</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->