### PR TITLE
feat(cli): add brief compressed summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,24 @@ You get an at-a-glance view of your project's technical debt health and trends.
 todo-scan stats --since main
 ```
 
+### Compressed Brief Summary
+
+🔥 **Problem**
+
+AI agents and developers working in token-constrained environments need a quick TODO landscape overview without consuming excessive context window or screen space.
+
+🌱 **Solution**
+
+`todo-scan brief` produces a compressed 2-4 line summary showing total counts, priority breakdown, and the single most urgent item, with optional `--since <ref>` for trend info and `--budget N` to cap output lines.
+
+🎁 **Outcome**
+
+You get the essential TODO health signal in minimal output, ideal for CI summaries and AI agent context.
+
+```sh
+todo-scan brief --since main --budget 2
+```
+
 ### Git Blame Integration
 
 🔥 **Problem**
@@ -622,6 +640,22 @@ todo-scan stats --since main
 
 # JSON output
 todo-scan stats --format json
+```
+
+### Brief summary
+
+```bash
+# Compressed summary (2-4 lines)
+todo-scan brief
+
+# With trend info compared to a git ref
+todo-scan brief --since main
+
+# Limit output to N lines
+todo-scan brief --budget 1
+
+# JSON output
+todo-scan brief --format json
 ```
 
 ### Lint TODO formatting

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -1,0 +1,162 @@
+use std::collections::HashSet;
+
+use crate::model::*;
+
+pub fn compute_brief(scan: &ScanResult, diff: Option<&DiffResult>) -> BriefResult {
+    let total_items = scan.items.len();
+
+    let total_files = scan
+        .items
+        .iter()
+        .map(|i| i.file.as_str())
+        .collect::<HashSet<_>>()
+        .len();
+
+    let mut normal = 0;
+    let mut high = 0;
+    let mut urgent = 0;
+    for item in &scan.items {
+        match item.priority {
+            Priority::Normal => normal += 1,
+            Priority::High => high += 1,
+            Priority::Urgent => urgent += 1,
+        }
+    }
+
+    let top_urgent = scan
+        .items
+        .iter()
+        .filter(|i| i.priority != Priority::Normal)
+        .max_by(|a, b| {
+            a.priority
+                .cmp(&b.priority)
+                .then_with(|| a.tag.severity().cmp(&b.tag.severity()))
+        })
+        .cloned();
+
+    BriefResult {
+        total_items,
+        total_files,
+        priority_counts: PriorityCounts {
+            normal,
+            high,
+            urgent,
+        },
+        top_urgent,
+        trend: diff.map(|d| TrendInfo {
+            added: d.added_count,
+            removed: d.removed_count,
+            base_ref: d.base_ref.clone(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::helpers::make_item;
+
+    #[test]
+    fn test_basic_counts() {
+        let mut items = vec![
+            make_item("a.rs", 1, Tag::Todo, "task one"),
+            make_item("a.rs", 2, Tag::Todo, "task two"),
+            make_item("b.rs", 1, Tag::Fixme, "fix this"),
+        ];
+        items[1].priority = Priority::High;
+        items[2].priority = Priority::Urgent;
+
+        let scan = ScanResult {
+            items,
+            files_scanned: 2,
+            ignored_items: vec![],
+        };
+
+        let result = compute_brief(&scan, None);
+        assert_eq!(result.total_items, 3);
+        assert_eq!(result.total_files, 2);
+        assert_eq!(result.priority_counts.normal, 1);
+        assert_eq!(result.priority_counts.high, 1);
+        assert_eq!(result.priority_counts.urgent, 1);
+    }
+
+    #[test]
+    fn test_top_urgent_selected() {
+        let mut items = vec![
+            make_item("a.rs", 1, Tag::Todo, "normal task"),
+            make_item("b.rs", 5, Tag::Bug, "urgent bug"),
+            make_item("c.rs", 10, Tag::Todo, "high task"),
+        ];
+        items[1].priority = Priority::Urgent;
+        items[2].priority = Priority::High;
+
+        let scan = ScanResult {
+            items,
+            files_scanned: 3,
+            ignored_items: vec![],
+        };
+
+        let result = compute_brief(&scan, None);
+        let top = result.top_urgent.expect("should have a top urgent item");
+        assert_eq!(top.file, "b.rs");
+        assert_eq!(top.line, 5);
+        assert_eq!(top.priority, Priority::Urgent);
+        assert_eq!(top.tag, Tag::Bug);
+    }
+
+    #[test]
+    fn test_top_urgent_none_when_all_normal() {
+        let items = vec![
+            make_item("a.rs", 1, Tag::Todo, "task one"),
+            make_item("b.rs", 1, Tag::Note, "note"),
+        ];
+
+        let scan = ScanResult {
+            items,
+            files_scanned: 2,
+            ignored_items: vec![],
+        };
+
+        let result = compute_brief(&scan, None);
+        assert!(result.top_urgent.is_none());
+    }
+
+    #[test]
+    fn test_trend_from_diff() {
+        let scan = ScanResult {
+            items: vec![make_item("a.rs", 1, Tag::Todo, "task")],
+            files_scanned: 1,
+            ignored_items: vec![],
+        };
+        let diff = DiffResult {
+            entries: vec![],
+            added_count: 5,
+            removed_count: 2,
+            base_ref: "main".to_string(),
+        };
+
+        let result = compute_brief(&scan, Some(&diff));
+        let trend = result.trend.expect("should have trend info");
+        assert_eq!(trend.added, 5);
+        assert_eq!(trend.removed, 2);
+        assert_eq!(trend.base_ref, "main");
+    }
+
+    #[test]
+    fn test_empty_scan() {
+        let scan = ScanResult {
+            items: vec![],
+            files_scanned: 0,
+            ignored_items: vec![],
+        };
+
+        let result = compute_brief(&scan, None);
+        assert_eq!(result.total_items, 0);
+        assert_eq!(result.total_files, 0);
+        assert_eq!(result.priority_counts.normal, 0);
+        assert_eq!(result.priority_counts.high, 0);
+        assert_eq!(result.priority_counts.urgent, 0);
+        assert!(result.top_urgent.is_none());
+        assert!(result.trend.is_none());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,6 +152,17 @@ pub enum Command {
         since: Option<String>,
     },
 
+    /// Compressed summary of TODO landscape (2-4 lines)
+    Brief {
+        /// Git ref for trend comparison (e.g., "main")
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Maximum output lines
+        #[arg(long)]
+        budget: Option<usize>,
+    },
+
     /// Search TODO comments by message text or issue reference
     #[command(alias = "s")]
     Search {

--- a/src/cmd/brief.rs
+++ b/src/cmd/brief.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::brief::compute_brief;
+use crate::cli::Format;
+use crate::config::Config;
+use crate::diff::compute_diff;
+use crate::output::print_brief;
+
+use super::do_scan;
+
+pub fn cmd_brief(
+    root: &Path,
+    config: &Config,
+    format: &Format,
+    since: Option<String>,
+    budget: Option<usize>,
+    no_cache: bool,
+) -> Result<()> {
+    let scan = do_scan(root, config, no_cache)?;
+
+    let diff = if let Some(ref base_ref) = since {
+        Some(compute_diff(&scan, base_ref, root, config)?)
+    } else {
+        None
+    };
+
+    let result = compute_brief(&scan, diff.as_ref());
+    print_brief(&result, format, budget);
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 mod blame;
+mod brief;
 mod check;
 mod clean;
 mod context;
@@ -14,6 +15,7 @@ mod tasks;
 mod workspace;
 
 pub use self::blame::{cmd_blame, BlameOptions};
+pub use self::brief::cmd_brief;
 pub use self::check::{cmd_check, cmd_workspace_check};
 pub use self::clean::cmd_clean;
 pub use self::context::cmd_context;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod blame;
+mod brief;
 mod cache;
 mod check;
 mod clean;
@@ -137,6 +138,9 @@ fn run() -> Result<()> {
                     cmd_search(&root, &config, &cli.format, opts, no_cache)
                 }
                 Command::Stats { since } => cmd_stats(&root, &config, &cli.format, since, no_cache),
+                Command::Brief { since, budget } => {
+                    cmd_brief(&root, &config, &cli.format, since, budget, no_cache)
+                }
                 Command::Diff {
                     git_ref,
                     tag,

--- a/src/model.rs
+++ b/src/model.rs
@@ -466,6 +466,15 @@ pub struct RelateResult {
     pub target: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct BriefResult {
+    pub total_items: usize,
+    pub total_files: usize,
+    pub priority_counts: PriorityCounts,
+    pub top_urgent: Option<TodoItem>,
+    pub trend: Option<TrendInfo>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/integration_brief.rs
+++ b/tests/integration_brief.rs
@@ -1,0 +1,128 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn todo_scan() -> Command {
+    assert_cmd::cargo_bin_cmd!("todo-scan")
+}
+
+fn setup_project(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    for (path, content) in files {
+        let full_path = dir.path().join(path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(full_path, content).unwrap();
+    }
+    dir
+}
+
+#[test]
+fn test_brief_basic_output() {
+    let dir = setup_project(&[
+        ("main.rs", "// TODO: implement feature\n// FIXME: broken\n"),
+        ("lib.rs", "// HACK: workaround\n"),
+    ]);
+
+    todo_scan()
+        .args(["brief", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("3 TODOs across 2 files"));
+}
+
+#[test]
+fn test_brief_with_priorities() {
+    let dir = setup_project(&[(
+        "main.rs",
+        "// TODO!!: urgent task\n// TODO!: high task\n// TODO: normal task\n",
+    )]);
+
+    todo_scan()
+        .args(["brief", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 urgent"))
+        .stdout(predicate::str::contains("1 high"));
+}
+
+#[test]
+fn test_brief_no_priority_shown_when_all_normal() {
+    let dir = setup_project(&[("main.rs", "// TODO: task one\n// TODO: task two\n")]);
+
+    todo_scan()
+        .args(["brief", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2 TODOs across 1 files"))
+        .stdout(predicate::str::contains("urgent").not())
+        .stdout(predicate::str::contains("high").not());
+}
+
+#[test]
+fn test_brief_top_urgent_line() {
+    let dir = setup_project(&[(
+        "main.rs",
+        "// TODO: normal\n// BUG!!: crash on large files\n",
+    )]);
+
+    todo_scan()
+        .args(["brief", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Top urgent:"))
+        .stdout(predicate::str::contains("BUG!!"))
+        .stdout(predicate::str::contains("crash on large files"));
+}
+
+#[test]
+fn test_brief_json_format() {
+    let dir = setup_project(&[("main.rs", "// TODO: json test\n// FIXME!: high fix\n")]);
+
+    todo_scan()
+        .args([
+            "brief",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"total_items\": 2"))
+        .stdout(predicate::str::contains("\"total_files\": 1"))
+        .stdout(predicate::str::contains("\"priority_counts\""))
+        .stdout(predicate::str::contains("\"top_urgent\""));
+}
+
+#[test]
+fn test_brief_budget_limits_lines() {
+    let dir = setup_project(&[("main.rs", "// TODO!!: urgent task\n// TODO: normal task\n")]);
+
+    // With budget=1, only the summary line should appear
+    todo_scan()
+        .args([
+            "brief",
+            "--root",
+            dir.path().to_str().unwrap(),
+            "--budget",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("TODOs across"))
+        .stdout(predicate::str::contains("Top urgent:").not());
+}
+
+#[test]
+fn test_brief_empty_project() {
+    let dir = setup_project(&[("main.rs", "fn main() {}\n")]);
+
+    todo_scan()
+        .args(["brief", "--root", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 TODOs across 0 files"));
+}


### PR DESCRIPTION
## Summary

- Add `todo-scan brief` subcommand for compressed 2-4 line TODO landscape summary
- Support `--since <ref>` for trend comparison and `--budget N` to limit output lines
- Include text and JSON output formats

Closes #101

## Test Plan

- [x] Unit tests: 5 tests in `src/brief.rs` (empty scan, basic counts, top urgent selection, no urgent when all normal, trend from diff)
- [x] Integration tests: 7 tests in `tests/integration_brief.rs` (basic output, empty project, priorities, no-priority display, top urgent line, JSON format, budget truncation)
- [x] Full test suite passes (322+ unit tests + all integration tests)
- [x] `cargo fmt --check` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `brief` command that produces a compressed 2-4 line summary of the TODO landscape, ideal for token-constrained environments like AI agents and CI summaries.

**Key Changes:**
- New `todo-scan brief` subcommand with `--since <ref>` for trend comparison and `--budget N` to limit output lines
- Supports both text and JSON output formats via global `--format` flag
- Displays total TODO counts, priority breakdown (urgent/high), the single most urgent item, and optional trend info
- Comprehensive test coverage: 5 unit tests in `src/brief.rs` and 7 integration tests in `tests/integration_brief.rs`
- Clean integration into existing codebase following established patterns

**Minor Issues:**
- Text output has minor grammar issues with pluralization ("1 files" should be "1 file")
- Trend output text is slightly redundant ("+5 added" could be cleaner as "+5")

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured, follows existing codebase patterns, and has excellent test coverage (12 tests total). The only issues are minor style improvements around text formatting and pluralization, which don't affect functionality. The code properly integrates with existing systems (scanner, diff, config) and handles edge cases (empty scans, no priorities, budget limiting).
- No files require special attention - only minor style improvements suggested in `src/output/mod.rs`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/brief.rs | New module implementing brief summary computation logic with comprehensive unit tests (5 tests covering all edge cases) |
| src/cmd/brief.rs | Command handler correctly orchestrates scan, optional diff computation, and output formatting |
| src/model.rs | Added `BriefResult` struct with proper serialization support for JSON output |
| src/output/mod.rs | Implements `print_brief` with text and JSON formatting; text output has minor grammar and clarity issues |
| tests/integration_brief.rs | Comprehensive integration tests (7 tests) covering all features including edge cases, priorities, JSON format, and budget limiting |

</details>



<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs: todo-scan brief] --> B[main.rs: parse CLI args]
    B --> C[cmd/brief.rs: cmd_brief]
    C --> D[do_scan: scan codebase]
    D --> E{--since flag?}
    E -->|Yes| F[compute_diff: compare with git ref]
    E -->|No| G[Skip diff]
    F --> H[brief.rs: compute_brief]
    G --> H
    H --> I[Count total items & files]
    I --> J[Count priorities: normal/high/urgent]
    J --> K[Find top urgent item by priority + severity]
    K --> L[Create BriefResult]
    L --> M{--format flag?}
    M -->|text| N[output/mod.rs: print_brief text]
    M -->|json| O[output/mod.rs: print_brief JSON]
    N --> P{--budget flag?}
    P -->|Yes| Q[Limit lines to budget]
    P -->|No| R[Print all lines]
    Q --> S[Output to stdout]
    R --> S
    O --> S
```
</details>


<sub>Last reviewed commit: c92014a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->