### PR TITLE
fix(security): comprehensive security hardening from agent review

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -18,7 +18,7 @@ fn detect_changed_files(
     base_files: &HashSet<String>,
     current: &ScanResult,
 ) -> HashSet<String> {
-    let diff_from_ref = git_command(&["diff", "--name-only", base_ref], root);
+    let diff_from_ref = git_command(&["diff", "--name-only", "--", base_ref], root);
     let diff_unstaged = git_command(&["diff", "--name-only"], root);
 
     // If either diff command failed, fall back to all files

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -416,8 +416,8 @@ const REPORT_DATA = {safe_json};
     tr.innerHTML =
       '<td>' + escapeHtml(item.file) + '</td>' +
       '<td>' + item.line + '</td>' +
-      '<td><span class="tag tag-' + item.tag + '">' + item.tag + '</span></td>' +
-      '<td class="' + priorityClass + '">' + item.priority + '</td>' +
+      '<td><span class="tag tag-' + escapeHtml(item.tag) + '">' + escapeHtml(item.tag) + '</span></td>' +
+      '<td class="' + escapeHtml(priorityClass) + '">' + escapeHtml(item.priority) + '</td>' +
       '<td>' + escapeHtml(item.message) + '</td>' +
       '<td>' + escapeHtml(item.author || '') + '</td>';
     tbody.appendChild(tr);

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -87,7 +87,9 @@ pub fn format_search(result: &SearchResult) -> String {
     lines.push(String::new());
     lines.push(format!(
         "**{} matches across {} files** (query: \"{}\")",
-        result.match_count, result.file_count, result.query
+        result.match_count,
+        result.file_count,
+        escape_cell(&result.query)
     ));
     lines.push(String::new());
     lines.join("\n")
@@ -116,7 +118,9 @@ pub fn format_diff(result: &DiffResult) -> String {
     lines.push(String::new());
     lines.push(format!(
         "**+{} -{}** (base: `{}`)",
-        result.added_count, result.removed_count, result.base_ref
+        result.added_count,
+        result.removed_count,
+        escape_cell(&result.base_ref)
     ));
     lines.push(String::new());
     lines.join("\n")
@@ -476,5 +480,26 @@ mod tests {
         let output = format_check(&result);
         assert!(output.contains("## FAIL"));
         assert!(output.contains("- **max**: 10 exceeds max 5"));
+    }
+
+    #[test]
+    fn test_format_search_escapes_query() {
+        let result = SearchResult {
+            query: "test[inject](url)".to_string(),
+            exact: false,
+            items: vec![],
+            match_count: 0,
+            file_count: 0,
+        };
+        let output = format_search(&result);
+        assert!(
+            output.contains("\\[inject\\]"),
+            "query should have brackets escaped, got: {}",
+            output
+        );
+        assert!(
+            !output.contains("[inject](url)"),
+            "raw query should not appear unescaped"
+        );
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -153,7 +153,7 @@ pub fn print_list(
                             println!(
                                 "    {} {}",
                                 format!("{:>4}", cl.line_number).dimmed(),
-                                cl.content.dimmed()
+                                sanitize_for_terminal(&cl.content).dimmed()
                             );
                         }
                     }
@@ -198,7 +198,7 @@ pub fn print_list(
                             println!(
                                 "    {} {}",
                                 format!("{:>4}", cl.line_number).dimmed(),
-                                cl.content.dimmed()
+                                sanitize_for_terminal(&cl.content).dimmed()
                             );
                         }
                         println!();
@@ -324,7 +324,7 @@ pub fn print_search(
                             println!(
                                 "    {} {}",
                                 format!("{:>4}", cl.line_number).dimmed(),
-                                cl.content.dimmed()
+                                sanitize_for_terminal(&cl.content).dimmed()
                             );
                         }
                     }
@@ -369,7 +369,7 @@ pub fn print_search(
                             println!(
                                 "    {} {}",
                                 format!("{:>4}", cl.line_number).dimmed(),
-                                cl.content.dimmed()
+                                sanitize_for_terminal(&cl.content).dimmed()
                             );
                         }
                         println!();
@@ -450,7 +450,7 @@ pub fn print_diff(
                         println!(
                             "    {} {}",
                             format!("{:>4}", cl.line_number).dimmed(),
-                            cl.content.dimmed()
+                            sanitize_for_terminal(&cl.content).dimmed()
                         );
                     }
                 }
@@ -472,7 +472,7 @@ pub fn print_diff(
                         println!(
                             "    {} {}",
                             format!("{:>4}", cl.line_number).dimmed(),
-                            cl.content.dimmed()
+                            sanitize_for_terminal(&cl.content).dimmed()
                         );
                     }
                     println!();
@@ -838,7 +838,7 @@ pub fn print_blame(result: &BlameResult, format: &Format) {
             }
 
             for (file, entries) in &groups {
-                println!("{}", file.bold().underline());
+                println!("{}", sanitize_for_terminal(file).bold().underline());
                 for entry in entries {
                     let tag_str = colorize_tag(&entry.item.tag);
                     let stale_marker = if entry.stale {
@@ -917,7 +917,7 @@ pub fn print_context(rich: &RichContext, format: &Format) {
                 println!(
                     "  {} {}",
                     format!("{:>4}", cl.line_number).dimmed(),
-                    cl.content.dimmed()
+                    sanitize_for_terminal(&cl.content).dimmed()
                 );
             }
 
@@ -931,7 +931,7 @@ pub fn print_context(rich: &RichContext, format: &Format) {
                 println!(
                     "  {} {}",
                     format!("{:>4}", cl.line_number).dimmed(),
-                    cl.content.dimmed()
+                    sanitize_for_terminal(&cl.content).dimmed()
                 );
             }
 
@@ -1070,7 +1070,7 @@ pub fn print_tasks(result: &TasksResult, format: &Format) {
 
             println!("\n{} tasks exported", result.total);
             if let Some(ref dir) = result.output_dir {
-                println!("Output: {}", dir);
+                println!("Output: {}", sanitize_for_terminal(dir));
             }
         }
         _ => {
@@ -1164,7 +1164,7 @@ fn sanitize_for_terminal(s: &str) -> String {
 pub fn print_report(report: &ReportResult, output_path: &str) -> std::io::Result<()> {
     let content = html::render_html(report);
     std::fs::write(output_path, content)?;
-    println!("Report written to {}", output_path);
+    println!("Report written to {}", sanitize_for_terminal(output_path));
     Ok(())
 }
 
@@ -1194,7 +1194,11 @@ pub fn print_workspace_list(
                 };
                 println!(
                     "  {:<20} {:<30} {:>6}  {:>6}  {}",
-                    pkg.name, pkg.path, pkg.todo_count, max_str, status_str
+                    sanitize_for_terminal(&pkg.name),
+                    sanitize_for_terminal(&pkg.path),
+                    pkg.todo_count,
+                    max_str,
+                    status_str
                 );
             }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -12,7 +12,7 @@ use crate::deadline::{parse_deadline, Deadline};
 use crate::model::{Priority, ScanResult, Tag, TodoItem};
 
 /// Maximum file size (10 MiB) to prevent OOM when scanning very large files.
-const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
+pub(crate) const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 
 /// Check if a file should be skipped based on its metadata size.
 fn should_skip_file(metadata: &std::fs::Metadata, max_size: u64) -> bool {


### PR DESCRIPTION
## Summary

- Comprehensive security review using 4-agent team (input, resource, output, dependency)
- Fixed 1 HIGH, 3 MEDIUM, and 5 LOW severity findings
- 9 findings accepted as low risk (standard CLI behavior or requiring attacker control over git repo)
- Full security review report posted as [issue comment](https://github.com/sotayamashita/todox/issues/125#issuecomment-3942647078)

### Fixes

| # | Severity | Finding | File(s) |
|---|----------|---------|---------|
| 1 | **HIGH** | Context lines not sanitized for terminal | `output/mod.rs` (8 locations) |
| 2 | MEDIUM | watch.rs reads files without size limit | `watch.rs` |
| 3 | MEDIUM | Workspace name/path not sanitized for terminal | `output/mod.rs` |
| 4 | MEDIUM | Markdown search query not escaped | `output/markdown.rs` |
| 5 | LOW | Missing `--` separator in git diff | `diff.rs` |
| 6 | LOW | Blame header file path not sanitized | `output/mod.rs` |
| 7 | LOW | Markdown diff base_ref not escaped | `output/markdown.rs` |
| 8 | LOW | HTML tag/priority not escaped | `output/html.rs` |
| 9 | LOW | Output dir/report paths not sanitized | `output/mod.rs` |

## Test plan

- [x] All 589 tests pass (353 unit + 236 integration)
- [x] `cargo fmt --check` clean
- [x] `cargo check` — no warnings
- [x] New tests: `test_update_file_skips_oversized_file`, `test_format_search_escapes_query`

Closes #125

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Comprehensive security hardening addressing 9 findings from a 4-agent security review. Fixed HIGH-severity ANSI escape injection in terminal output (8 locations), MEDIUM-severity file size validation in watch mode, and multiple LOW-severity issues in HTML/Markdown escaping and git command safety. All fixes include proper input sanitization, size limits, and output encoding. Two new tests added for validation.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - comprehensive security fixes with thorough test coverage
- All changes are defensive security improvements with clear benefits and no functional regressions. The fixes address real security issues (ANSI injection, XSS, OOM) using established sanitization patterns. Test suite passes (589 tests) with new coverage for the key fixes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/diff.rs | Added `--` separator to git diff command to prevent ambiguity between revisions and paths |
| src/output/html.rs | Escaped tag and priorityClass in HTML output to prevent XSS via crafted TODO tags |
| src/output/markdown.rs | Escaped search query and base_ref in Markdown output to prevent broken tables, includes test coverage |
| src/output/mod.rs | Applied sanitize_for_terminal() to 8 context line outputs and workspace name/path fields to prevent ANSI escape injection |
| src/scanner.rs | Changed MAX_FILE_SIZE from private to pub(crate) to enable reuse in watch module |
| src/watch.rs | Added file size check before reading to prevent OOM attacks on large files, includes test coverage |

</details>



<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Input] --> B{Input Type}
    B -->|File Content| C[Context Lines]
    B -->|Workspace Data| D[Package Name/Path]
    B -->|Search Query| E[Markdown Query]
    B -->|Git Ref| F[Git Diff Command]
    
    C --> G[sanitize_for_terminal]
    D --> G
    E --> H[escape_cell]
    F --> I[Add -- separator]
    
    G --> J[Strip Control Chars 0x00-0x1f]
    H --> K[Escape Markdown Special Chars]
    I --> L[Prevent Path/Rev Ambiguity]
    
    J --> M[Safe Terminal Output]
    K --> N[Safe Markdown Tables]
    L --> O[Safe Git Execution]
    
    P[File System] --> Q{File Size Check}
    Q -->|> 10 MiB| R[Skip & Remove TODOs]
    Q -->|<= 10 MiB| S[Read & Scan]
    
    S --> T[HTML Output]
    T --> U[escapeHtml tag/priority]
    U --> V[Safe HTML Report]
```
</details>


<sub>Last reviewed commit: 68f709a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->