### PR TITLE
docs(readme): remove experimental disclaimer callouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,6 @@
 
 [![CI](https://github.com/sotayamashita/todox/actions/workflows/ci.yml/badge.svg)](https://github.com/sotayamashita/todox/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/sotayamashita/todox/graph/badge.svg)](https://codecov.io/gh/sotayamashita/todox) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sotayamashita/todox)
 
-> [!WARNING]
-> **This is an experiment.** This repository exists to explore what AI can and cannot do across the entire software development lifecycle — and where human judgment remains essential. All code, issues, discussions, pull requests, and code reviews are authored and managed exclusively by [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with no human review. Use this project at your own risk. The maintainers assume no responsibility for any issues arising from its use.
-
-> [!NOTE]
-> This project used the prompt from the **"Start your first agent team"** section of the [Claude Code Agent Teams documentation](https://code.claude.com/docs/en/agent-teams) as-is:
->
-> ```
-> I'm designing a CLI tool that helps developers track TODO comments across
-> their codebase. Create an agent team to explore this from different angles: one
-> teammate on UX, one on technical architecture, one playing devil's advocate.
-> ```
-
 Track TODO/FIXME/HACK comments in your codebase with git-aware diff and CI gate.
 
 ## Features


### PR DESCRIPTION
## Summary

Remove the WARNING and NOTE callout blocks from README.md that were added during the experimental phase. These disclaimers undermine user confidence in a published crate and are no longer appropriate.

- Removed the `> [!WARNING]` block disclaiming responsibility
- Removed the `> [!NOTE]` block describing the Claude Code agent team prompt origin

Closes #79

## Test Plan

- [x] Both callout blocks removed from README.md
- [x] No broken formatting in surrounding content
- [x] README reads as a professional, publishable crate README

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed two GitHub-flavored callout blocks from the README that were undermining the project's credibility. The `[!WARNING]` block disclaimed responsibility and labeled the project as an experiment, while the `[!NOTE]` block explained the Claude Code agent team prompt origin. Both are appropriate to remove for a published crate that should present itself as production-ready.

- Deleted 14 lines total (12 lines of callout content + 2 blank lines)
- No functional changes to the project
- Formatting remains intact around the deletion point

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- This is a pure documentation change that removes 14 lines from README.md. No code logic, configuration, or functionality is affected. The surrounding markdown formatting is preserved correctly.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Removed experimental disclaimer callouts to present the crate as production-ready |

</details>



<sub>Last reviewed commit: 169b9e7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->