### PR TITLE
docs(readme): rewrite hero section to lead with CI gate value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,34 @@
 
 [![CI](https://github.com/sotayamashita/todox/actions/workflows/ci.yml/badge.svg)](https://github.com/sotayamashita/todox/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/sotayamashita/todox/graph/badge.svg)](https://codecov.io/gh/sotayamashita/todox) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sotayamashita/todox)
 
-Track TODO/FIXME/HACK comments in your codebase with git-aware diff and CI gate.
+A CI gate that fails your build when TODO comments exceed thresholds, so technical debt stays visible and under control.
+
+### Why not `grep -r TODO .`?
+
+- **No CI enforcement** — grep finds TODOs but can't fail a build when the count crosses a limit
+- **No git awareness** — grep can't show which TODOs were added in a branch or since a specific commit
+- **No structure** — grep gives raw text; todo-scan extracts tags, authors, priorities, issue refs, and deadlines
+- **No format enforcement** — grep can't reject malformed TODOs like `todo fix this` in a pre-merge check
+
+### Quick start
+
+```sh
+cargo install --path .
+
+# See what you have
+todo-scan list
+
+# Set a ceiling and enforce it in CI
+todo-scan check --max 100
+```
+
+### Key commands
+
+| Command | What it does |
+|---|---|
+| `todo-scan check --max 100` | CI gate — fails the build when TODO count exceeds the threshold |
+| `todo-scan diff main` | Shows TODOs added/removed since a git ref — useful in PR review |
+| `todo-scan lint` | Enforces consistent TODO formatting (uppercase, colon, author) |
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Replace the generic one-liner tagline with CI gate positioning
- Add "Why not grep?" comparison section answering the key objection
- Add quick start with install + `todo-scan check --max 100`
- Add key commands table highlighting `check`, `diff`, and `lint`
- Existing Features section and all content below unchanged

Closes #103

## Test Plan

- [ ] Verify rendered README on GitHub displays correctly
- [ ] Confirm no broken markdown links or formatting
- [ ] Verify all existing anchor links in Features index still work

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the generic tagline with a focused CI gate value proposition that immediately communicates how todo-scan prevents technical debt from growing uncontrolled. Adds three new sections before the Features list: a "Why not grep?" comparison addressing the key objection upfront, a Quick start with installation and essential commands, and a Key commands table highlighting the three most important operations (`check`, `diff`, `lint`). All existing content below the hero section remains unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that improves README clarity and positioning without touching any code, configuration, or functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Rewrites hero section with clear CI gate value proposition, adds comparison with grep, quick start guide, and key commands table |

</details>



<sub>Last reviewed commit: 36550d7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->