### PR TITLE
fix(plugin): update repository URLs from todox to todo-scan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,8 @@
       "author": {
         "name": "sotayamashita"
       },
-      "homepage": "https://github.com/sotayamashita/todox",
-      "repository": "https://github.com/sotayamashita/todox",
+      "homepage": "https://github.com/sotayamashita/todo-scan",
+      "repository": "https://github.com/sotayamashita/todo-scan",
       "license": "MIT",
       "keywords": ["todo", "fixme", "ci-gate", "code-quality", "scanner"],
       "category": "development",

--- a/README.md
+++ b/README.md
@@ -1015,13 +1015,13 @@ todo-scan provides a [Claude Code plugin](https://docs.anthropic.com/en/docs/cla
 ### Install from plugin marketplace (recommended)
 
 ```bash
-/plugin marketplace add sotayamashita/todox
+/plugin marketplace add sotayamashita/todo-scan
 ```
 
 ### Install with [skills CLI](https://github.com/vercel-labs/skills)
 
 ```bash
-npx skills add sotayamashita/todox
+npx skills add sotayamashita/todo-scan
 ```
 
 ### Manual install


### PR DESCRIPTION
## Summary
- Update `homepage` and `repository` URLs in `.claude-plugin/marketplace.json` from `sotayamashita/todox` to `sotayamashita/todo-scan`
- Update plugin install commands in `README.md` to reference `sotayamashita/todo-scan`

## Test plan
- [ ] Verify marketplace.json URLs point to the correct repository
- [ ] Verify README install commands use the correct repository name