### PR TITLE
chore(cargo): add crates.io publish metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,25 @@ name = "todo-scan"
 version = "0.1.0"
 edition = "2021"
 description = "Track TODO/FIXME/HACK comments with git-aware diff and CI gate"
+license = "MIT"
+repository = "https://github.com/sotayamashita/todo-scan"
+homepage = "https://github.com/sotayamashita/todo-scan"
+keywords = ["todo", "fixme", "ci", "lint", "code-quality"]
+categories = ["command-line-utilities", "development-tools"]
+readme = "README.md"
+exclude = [
+    "tests/",
+    "docs/",
+    ".github/",
+    ".claude/",
+    ".claude-plugin/",
+    "benches/",
+    "skills/",
+    "schema/",
+    "renovate.json",
+    ".todo-scan.toml",
+    "CLAUDE.md",
+]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A CI gate that fails your build when TODO comments exceed thresholds, so technic
 ### Quick start
 
 ```sh
-cargo install --path .
+cargo install todo-scan
 
 # See what you have
 todo-scan list
@@ -516,7 +516,7 @@ Glob patterns in member lists (e.g., `packages/*`, `crates/*`) are expanded auto
 ## Installation
 
 ```bash
-cargo install --path .
+cargo install todo-scan
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Add required and recommended crates.io metadata to `Cargo.toml` (`license`, `repository`, `homepage`, `keywords`, `categories`, `readme`, `exclude`)
- Exclude non-essential files from the published crate (`tests/`, `docs/`, `.github/`, `.claude/`, `.claude-plugin/`, `benches/`, `skills/`, `schema/`, `renovate.json`, `.todo-scan.toml`, `CLAUDE.md`)
- Update installation instructions in README.md from `cargo install --path .` to `cargo install todo-scan`

Closes #129

## Test plan

- [x] `cargo publish --dry-run --allow-dirty` — metadata validation and build passed
- [x] `cargo package --list --allow-dirty` — verified excluded files are not included
- [ ] `cargo publish` — actual publish (post-merge)
- [ ] `cargo install todo-scan` — verify installation from crates.io (post-publish)